### PR TITLE
Verify proposal existence before commit vote for a given proposal_id

### DIFF
--- a/frame/quorum/src/lib.rs
+++ b/frame/quorum/src/lib.rs
@@ -695,6 +695,14 @@ pub mod pallet {
     // Record the vote in the storage
     fn commit_vote(who: T::AccountId, proposal_id: Hash, in_favour: bool) -> DispatchResult {
       let block_number = T::Security::get_current_block_count();
+      ensure!(
+        Self::proposals().into_iter().find(|prop| {
+          let (id, _block_number, _proposal) = prop;
+          *id == proposal_id
+        }) != None,
+        Error::<T>::ProposalDoesNotExist
+      );
+
       let mut votes = Votes::<T>::get(proposal_id).unwrap_or_else(|| {
         let mut v =
           ProposalVotes::<T::BlockNumber, BoundedVec<T::AccountId, T::VotesLimit>>::default();

--- a/frame/quorum/src/lib.rs
+++ b/frame/quorum/src/lib.rs
@@ -696,10 +696,10 @@ pub mod pallet {
     fn commit_vote(who: T::AccountId, proposal_id: Hash, in_favour: bool) -> DispatchResult {
       let block_number = T::Security::get_current_block_count();
       ensure!(
-        Self::proposals().into_iter().find(|prop| {
-          let (id, _block_number, _proposal) = prop;
-          *id == proposal_id
-        }) != None,
+        Self::proposals()
+          .into_iter()
+          .find(|(id, _, _)| *id == proposal_id)
+          .is_some(),
         Error::<T>::ProposalDoesNotExist
       );
 

--- a/frame/quorum/src/tests.rs
+++ b/frame/quorum/src/tests.rs
@@ -142,7 +142,12 @@ pub fn vote_for_non_existent_proposal_should_fail() {
 
     let proposal_id = Hash::zero();
     assert_noop!(
-      Quorum::acknowledge_proposal(context.alice, proposal_id),
+      Quorum::acknowledge_proposal(context.alice.clone(), proposal_id),
+      Error::<Test>::ProposalDoesNotExist
+    );
+    let proposal_id = Hash::zero();
+    assert_noop!(
+      Quorum::reject_proposal(context.alice, proposal_id),
       Error::<Test>::ProposalDoesNotExist
     );
   });

--- a/frame/quorum/src/tests.rs
+++ b/frame/quorum/src/tests.rs
@@ -135,7 +135,7 @@ pub fn test_vec_shuffle() {
 }
 
 #[test]
-pub fn vote_for_non_existing_proposal_should_fail() {
+pub fn vote_for_non_existent_proposal_should_fail() {
   new_test_ext().execute_with(|| {
     let context = Context::default();
     context.setup();


### PR DESCRIPTION
* Updated the commit_vote function to search for proposal with provided proposal_id, and throw an error if it is not found in Proposals storage.
* Added a new unit test `vote_for_non_existent_proposal_should_fail`
* Extracted the duplicated arrangement code into a struct called `Context` in unit tests to simplify the test implementations.