### PR TITLE
Add `try-runtime` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "beef"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1078,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
+ "sct 0.6.1",
 ]
 
 [[package]]
@@ -1748,6 +1757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-try-runtime"
+version = "0.10.0-dev"
+source = "git+https://github.com/tidelabs/substrate?branch=tidechain#77c15d2546276a865b6e8f1c5d4b1d0ec1961e72"
+dependencies = [
+ "frame-support",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "fs-swap"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,8 +1905,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
 dependencies = [
  "futures-io",
- "rustls",
- "webpki",
+ "rustls 0.19.1",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2273,11 +2293,11 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2630,6 +2650,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373a33d987866ccfe1af4bc11b089dce941764313f9fd8b7cf13fcb51b72dc5"
+dependencies = [
+ "jsonrpsee-types 0.4.1",
+ "jsonrpsee-utils",
+ "jsonrpsee-ws-client 0.4.1",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fd8cd6c6b1bbd06881d2cf88f1fc83cc36c98f2219090f839115fb4a956cb9"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types 0.8.0",
+ "jsonrpsee-ws-client 0.8.0",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3303cdf246e6ab76e2866fb3d9acb6c76a068b1b28bd923a1b7a8122257ad7b5"
+dependencies = [
+ "futures 0.3.21",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types 0.8.0",
+ "pin-project 1.0.10",
+ "rustls-native-certs 0.6.2",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.23.3",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 0.22.3",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f220b5a238dc7992b90f1144fbf6eaa585872c9376afe6fe6863ffead6191bf3"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.2",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types 0.8.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4299ebf790ea9de1cb72e73ff2ae44c723ef264299e5e2d5ef46a371eb3ac3d8"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f778cf245158fbd8f5d50823a2e9e4c708a40be164766bd35e9fb1d86715b2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "log",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b3f601bbbe45cd63f5407b6f7d7950e08a7d4f82aa699ff41a4a5e9e54df58"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-utils"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0109c4f972058f3b1925b73a17210aff7b63b65967264d0045d15ee88fe84f0c"
+dependencies = [
+ "arrayvec 0.7.2",
+ "beef",
+ "jsonrpsee-types 0.4.1",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559aa56fc402af206c00fc913dc2be1d9d788dcde045d14df141a535245d35ef"
+dependencies = [
+ "arrayvec 0.7.2",
+ "async-trait",
+ "fnv",
+ "futures 0.3.21",
+ "http",
+ "jsonrpsee-types 0.4.1",
+ "log",
+ "pin-project 1.0.10",
+ "rustls-native-certs 0.5.0",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "tokio-util",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff425cee7c779e33920913bc695447416078ee6d119f443f3060feffa4e86b5"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types 0.8.0",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2882,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal",
  "log",
  "pallet-asset-registry",
@@ -3283,7 +3462,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url 2.2.2",
- "webpki-roots",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -5564,6 +5743,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "remote-externalities"
+version = "0.10.0-dev"
+source = "git+https://github.com/tidelabs/substrate?branch=tidechain#77c15d2546276a865b6e8f1c5d4b1d0ec1961e72"
+dependencies = [
+ "env_logger",
+ "jsonrpsee 0.8.0",
+ "log",
+ "parity-scale-codec",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-version",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5682,8 +5878,20 @@ dependencies = [
  "base64",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5693,9 +5901,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -6722,6 +6951,16 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -8040,6 +8279,7 @@ dependencies = [
  "substrate-build-script-utils",
  "thiserror",
  "tidechain-service",
+ "try-runtime-cli",
 ]
 
 [[package]]
@@ -8129,6 +8369,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal",
  "log",
  "pallet-asset-registry",
@@ -8162,7 +8403,6 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-reward-curve",
- "pallet-sudo",
  "pallet-tidefi",
  "pallet-tidefi-rpc-runtime-api",
  "pallet-tidefi-stake",
@@ -8377,7 +8617,19 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "signal-hook-registry",
  "socket2 0.4.4",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8386,9 +8638,20 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
+dependencies = [
+ "rustls 0.20.4",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -8410,6 +8673,7 @@ checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite 0.2.8",
@@ -8588,6 +8852,31 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "try-runtime-cli"
+version = "0.10.0-dev"
+source = "git+https://github.com/tidelabs/substrate?branch=tidechain#77c15d2546276a865b6e8f1c5d4b1d0ec1961e72"
+dependencies = [
+ "clap 3.1.6",
+ "jsonrpsee 0.4.1",
+ "log",
+ "parity-scale-codec",
+ "remote-externalities",
+ "sc-chain-spec",
+ "sc-cli",
+ "sc-executor",
+ "sc-service",
+ "serde",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-version",
+ "zstd",
+]
 
 [[package]]
 name = "tt-call"
@@ -9132,12 +9421,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ overflow-checks = true
 
 [features]
 runtime-benchmarks= [ "tidechain-cli/runtime-benchmarks" ]
+try-runtime = [ "tidechain-cli/try-runtime" ]
 
 # Configuration for building a .deb package - for use with `cargo-deb`
 [package.metadata.deb]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,17 +25,22 @@ sc-cli = { git = "https://github.com/tidelabs/substrate", branch = "tidechain", 
 sc-service = { git = "https://github.com/tidelabs/substrate", branch = "tidechain", features = ["wasmtime"], optional = true }
 tidechain-service = { path = "../node/service", optional = true, default-features = false }
 
-# These dependencies are used for runtime benchmarking
-frame-benchmarking = { git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
-frame-benchmarking-cli = { git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
+frame-benchmarking = { git = "https://github.com/tidelabs/substrate", branch = "tidechain", optional = true }
+frame-benchmarking-cli = { git = "https://github.com/tidelabs/substrate", branch = "tidechain", optional = true }
+try-runtime-cli = { git = "https://github.com/tidelabs/substrate", branch = "tidechain", optional = true }
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 
 [features]
 default = [ "tidechain-native", "full-node", "cli" ]
-try-runtime = []
+try-runtime = [
+	"try-runtime-cli",
+	"tidechain-service/try-runtime"	
+]
 runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-benchmarking-cli",	
 	"tidechain-service/runtime-benchmarks",
 ]
 cli = [

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -50,7 +50,12 @@ pub enum Subcommand {
 
   ExportBuiltinWasm(ExportBuiltinWasmCommand),
 
+  /// Try some command against runtime state.
+  #[cfg(feature = "try-runtime")]
+  TryRuntime(try_runtime_cli::TryRuntimeCmd),
+
   /// The custom benchmark subcommmand benchmarking runtime pallets.
+  #[cfg(feature = "runtime-benchmarks")]
   Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
   /// Key management CLI utilities

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -84,6 +84,9 @@ runtime-benchmarks = [
 	"tidechain-runtime/runtime-benchmarks",
 	"lagoon-runtime/runtime-benchmarks",
 ]
-
+try-runtime = [
+	"tidechain-runtime/try-runtime",
+	"lagoon-runtime/try-runtime",
+]
 tidechain-native = [ "tidechain-runtime", "tidechain-client/tidechain" ]
 lagoon-native = [ "lagoon-runtime", "tidechain-client/lagoon" ]

--- a/runtime/common/api.rs
+++ b/runtime/common/api.rs
@@ -239,10 +239,14 @@ impl_runtime_apis! {
 
    #[cfg(feature = "try-runtime")]
    impl frame_try_runtime::TryRuntime<Block> for Runtime {
-       fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
-           let weight = Executive::try_runtime_upgrade()?;
-           Ok((weight, RuntimeBlockWeights::get().max_block))
-       }
+     fn on_runtime_upgrade() -> (frame_support::weights::Weight, frame_support::weights::Weight) {
+        log::info!("try-runtime::on_runtime_upgrade tidechain.");
+        let weight = Executive::try_runtime_upgrade().unwrap();
+        (weight, crate::types::RuntimeBlockWeights::get().max_block)
+     }
+     fn execute_block_no_check(block: Block) -> frame_support::weights::Weight {
+        Executive::execute_block_no_check(block)
+     }
    }
 
    #[cfg(feature = "runtime-benchmarks")]

--- a/runtime/lagoon/Cargo.toml
+++ b/runtime/lagoon/Cargo.toml
@@ -95,6 +95,8 @@ pallet-fees = { path = "../../frame/fees", default-features = false }
 pallet-assets = { default-features = false, path = "../../frame/assets" }
 pallet-asset-registry = { path = "../../frame/asset-registry", default-features = false }
 
+frame-try-runtime = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain", optional = true }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 
@@ -107,6 +109,7 @@ std = [
     "scale-info/std",
     'codec/std',
     'log/std',
+    'frame-try-runtime/std',
     'frame-executive/std',
     'frame-support/std',
     'frame-system/std',
@@ -199,11 +202,42 @@ runtime-benchmarks = [
     "pallet-assets/runtime-benchmarks",
     'pallet-bags-list/runtime-benchmarks',
 	"pallet-preimage/runtime-benchmarks",
-    
     "pallet-fees/runtime-benchmarks",
     "pallet-tidefi/runtime-benchmarks",
     "pallet-tidefi-stake/runtime-benchmarks",
     "pallet-quorum/runtime-benchmarks",
     "pallet-oracle/runtime-benchmarks",
     "pallet-asset-registry/runtime-benchmarks",
+]
+
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-authority-discovery/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-babe/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-bounties/try-runtime",
+	"pallet-collective/try-runtime",
+	"pallet-elections-phragmen/try-runtime",
+	"pallet-grandpa/try-runtime",
+	"pallet-im-online/try-runtime",
+	"pallet-indices/try-runtime",
+	"pallet-membership/try-runtime",
+	"pallet-multisig/try-runtime",
+	"pallet-identity/try-runtime",
+	"pallet-scheduler/try-runtime",
+	"pallet-offences/try-runtime",
+	"pallet-proxy/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-staking/try-runtime",
+	"pallet-election-provider-multi-phase/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-tips/try-runtime",
+	"pallet-transaction-payment/try-runtime",
+	"pallet-treasury/try-runtime",
+	"pallet-utility/try-runtime",
+	"pallet-sudo/try-runtime",
 ]

--- a/runtime/tidechain/Cargo.toml
+++ b/runtime/tidechain/Cargo.toml
@@ -27,7 +27,6 @@ pallet-session = { default-features = false, git = "https://github.com/tidelabs/
 pallet-staking = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 pallet-multisig = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 pallet-staking-reward-curve = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
-pallet-sudo = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 pallet-utility = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 pallet-timestamp = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 pallet-transaction-payment = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
@@ -95,6 +94,8 @@ pallet-fees = { path = "../../frame/fees", default-features = false }
 pallet-assets = { default-features = false, path = "../../frame/assets" }
 pallet-asset-registry = { path = "../../frame/asset-registry", default-features = false }
 
+frame-try-runtime = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain", optional = true }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 
@@ -107,6 +108,7 @@ std = [
     "scale-info/std",
     'codec/std',
     'log/std',
+    'frame-try-runtime/std',
     'frame-executive/std',
     'frame-support/std',
     'frame-system/std',
@@ -122,7 +124,6 @@ std = [
     'pallet-staking/std',
     'pallet-authority-discovery/std',
     'pallet-multisig/std',
-    'pallet-sudo/std',
     'pallet-indices/std',
     'pallet-identity/std',
     'pallet-proxy/std',
@@ -206,4 +207,34 @@ runtime-benchmarks = [
     "pallet-quorum/runtime-benchmarks",
     "pallet-oracle/runtime-benchmarks",
     "pallet-asset-registry/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-authority-discovery/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-babe/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-bounties/try-runtime",
+	"pallet-collective/try-runtime",
+	"pallet-elections-phragmen/try-runtime",
+	"pallet-grandpa/try-runtime",
+	"pallet-im-online/try-runtime",
+	"pallet-indices/try-runtime",
+	"pallet-membership/try-runtime",
+	"pallet-multisig/try-runtime",
+	"pallet-identity/try-runtime",
+	"pallet-scheduler/try-runtime",
+	"pallet-offences/try-runtime",
+	"pallet-proxy/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-staking/try-runtime",
+	"pallet-election-provider-multi-phase/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-tips/try-runtime",
+	"pallet-transaction-payment/try-runtime",
+	"pallet-treasury/try-runtime",
+	"pallet-utility/try-runtime",
 ]


### PR DESCRIPTION
This bring `try-runtime` feature to Tidechain cli

Example:
```
tidechain try-runtime offchain-worker live --uri <tidechain_uri> --at <block_hash>
```

More details can be found here;
https://docs.substrate.io/v3/tools/try-runtime/