### PR TITLE
Refactored oracle pallet unit tests

### DIFF
--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -32,6 +32,96 @@ use tidefi_primitives::{
   Balance, CurrencyId, Hash, SwapConfirmation, SwapStatus, SwapType,
 };
 
+// TEMP Asset
+const TEMP_ASSET_ID: u32 = 4;
+const TEMP_CURRENCY_ID: CurrencyId = CurrencyId::Wrapped(TEMP_ASSET_ID);
+const TEMP_ASSET_IS_SUFFICIENT: bool = true;
+const TEMP_ASSET_MIN_BALANCE: u128 = 1;
+
+// TEMP Asset Metadata
+const TEMP_ASSET_NAME: &str = "TEMP";
+const TEMP_ASSET_SYMBOL: &str = "TEMP";
+const TEMP_ASSET_NUMBER_OF_DECIMAL_PLACES: u8 = 2;
+
+// Asset Units
+const ONE_TEMP: u128 = 100;
+const ONE_MILLI_TIFI: u128 = 1_000_000_000;
+const ONE_TIFI: u128 = 1_000 * ONE_MILLI_TIFI;
+
+// Test Accounts
+const ALICE_ACCOUNT_ID: u64 = 1;
+const BOB_ACCOUNT_ID: u64 = 2;
+const CHARLIE_ACCOUNT_ID: u64 = 3;
+const DAVE_ACCOUNT_ID: u64 = 4;
+
+// Extrinsic Hashes
+const EXTRINSIC_HASH_0: [u8; 32] = [0; 32];
+const EXTRINSIC_HASH_1: [u8; 32] = [1; 32];
+const EXTRINSIC_HASH_2: [u8; 32] = [2; 32];
+
+struct Context {
+  alice: Origin,
+  bob: Origin,
+}
+
+impl Default for Context {
+  fn default() -> Self {
+    Self {
+      alice: Origin::signed(ALICE_ACCOUNT_ID),
+      bob: Origin::signed(BOB_ACCOUNT_ID),
+    }
+  }
+}
+
+impl Context {
+  fn set_oracle_status(self, status: bool) -> Self {
+    assert_ok!(Oracle::set_status(self.alice.clone(), status));
+    match status {
+      true => assert!(Oracle::status()),
+      false => assert!(!Oracle::status()),
+    }
+    self
+  }
+
+  fn create_temp_asset_and_metadata(self) -> Self {
+    let temp_asset_owner = ALICE_ACCOUNT_ID;
+
+    assert_ok!(Assets::force_create(
+      Origin::root(),
+      TEMP_ASSET_ID,
+      temp_asset_owner,
+      TEMP_ASSET_IS_SUFFICIENT,
+      TEMP_ASSET_MIN_BALANCE
+    ));
+
+    assert_ok!(Assets::set_metadata(
+      Origin::signed(temp_asset_owner),
+      TEMP_ASSET_ID,
+      TEMP_ASSET_NAME.into(),
+      TEMP_ASSET_SYMBOL.into(),
+      TEMP_ASSET_NUMBER_OF_DECIMAL_PLACES
+    ));
+
+    self
+  }
+
+  fn mint_tifi(self, account: u64, amount: u128) -> Self {
+    Self::mint_asset_for_accounts(vec![account], CurrencyId::Tifi, amount);
+    self
+  }
+
+  fn mint_temp(self, account: u64, amount: u128) -> Self {
+    Self::mint_asset_for_accounts(vec![account], TEMP_CURRENCY_ID, amount);
+    self
+  }
+
+  fn mint_asset_for_accounts(accounts: Vec<u64>, asset: CurrencyId, amount: u128) {
+    for account in accounts {
+      assert_ok!(Adapter::mint_into(asset, &account, amount));
+    }
+  }
+}
+
 #[test]
 pub fn check_genesis_config() {
   new_test_ext().execute_with(|| {
@@ -42,12 +132,15 @@ pub fn check_genesis_config() {
 #[test]
 pub fn set_operational_status_works() {
   new_test_ext().execute_with(|| {
-    let alice = Origin::signed(1u64);
-    let bob = Origin::signed(2u64);
-    assert_ok!(Oracle::set_status(alice.clone(), true));
-    assert_noop!(Oracle::set_status(bob, false), Error::<Test>::AccessDenied);
+    let context = Context::default();
+
+    assert_ok!(Oracle::set_status(context.alice.clone(), true));
+    assert_noop!(
+      Oracle::set_status(context.bob, false),
+      Error::<Test>::AccessDenied
+    );
     assert!(Oracle::status());
-    assert_ok!(Oracle::set_status(alice, false));
+    assert_ok!(Oracle::set_status(context.alice, false));
     assert!(!Oracle::status());
   });
 }
@@ -55,95 +148,39 @@ pub fn set_operational_status_works() {
 #[test]
 pub fn confirm_swap_partial_filling() {
   new_test_ext().execute_with(|| {
-    let alice = Origin::signed(1u64);
-    let bob_initial_balance: Balance = 20_000_000_000_000;
+    const BOB_INITIAL_BALANCE: Balance = 20 * ONE_TIFI;
+    const CHARLIE_INITIAL_WRAPPED_BALANCE: Balance = 10_000 * ONE_TEMP;
+    const DAVE_INITIAL_WRAPPED_BALANCE: Balance = 10_000 * ONE_TEMP;
+    const CHARLIE_INITIAL_TRADE: Balance = 4_000 * ONE_TEMP;
+
+    let context = Context::default()
+      .set_oracle_status(true)
+      .mint_tifi(ALICE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(CHARLIE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(DAVE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(BOB_ACCOUNT_ID, BOB_INITIAL_BALANCE)
+      .create_temp_asset_and_metadata()
+      .mint_temp(CHARLIE_ACCOUNT_ID, CHARLIE_INITIAL_WRAPPED_BALANCE)
+      .mint_temp(DAVE_ACCOUNT_ID, DAVE_INITIAL_WRAPPED_BALANCE);
 
     assert_eq!(Fees::account_id(), 8246216774960574317);
 
-    let temp_asset_id = 4;
-
-    assert_ok!(Oracle::set_status(alice.clone(), true));
-    assert!(Oracle::status());
-
-    // add 1 tifi to alice & all MMs
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &1u64,
-      1_000_000_000_000
-    ));
-
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &3u64,
-      1_000_000_000_000
-    ));
-
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &4u64,
-      1_000_000_000_000
-    ));
-
-    // add 20 tides to bob
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &2u64,
-      bob_initial_balance
-    ));
-
-    // create TEMP asset
-    assert_ok!(Assets::force_create(
-      Origin::root(),
-      temp_asset_id,
-      1u64,
-      true,
-      1
-    ));
-
-    // make TEMP asset as 2 decimals
-    assert_ok!(Assets::set_metadata(
-      alice.clone(),
-      temp_asset_id,
-      "TEMP".into(),
-      "TEMP".into(),
-      2
-    ));
-
-    // mint TEMP funds to the MMs
-    let charlie_initial_wrapped_balance: Balance = 1_000_000;
-    assert_ok!(Assets::mint(
-      alice.clone(),
-      temp_asset_id,
-      3u64,
-      charlie_initial_wrapped_balance
-    ));
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &3u64),
-      charlie_initial_wrapped_balance
+      Adapter::balance(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID),
+      CHARLIE_INITIAL_WRAPPED_BALANCE
     );
 
-    let dave_initial_wrapped_balance: Balance = 1_000_000;
-    assert_ok!(Assets::mint(
-      alice.clone(),
-      temp_asset_id,
-      4u64,
-      dave_initial_wrapped_balance
-    ));
-
     // BOB: 10 TIFI for 200 TEMP (20 TEMP/TIFI)
-    let bob_initial_trade: Balance = 10_000_000_000_000;
+    let bob_initial_trade: Balance = 10 * ONE_TIFI;
 
     let (trade_request_id, trade_request) = Oracle::add_new_swap_in_queue(
-      2u64,
+      BOB_ACCOUNT_ID,
       CurrencyId::Tifi,
       bob_initial_trade,
-      CurrencyId::Wrapped(temp_asset_id),
-      20_000,
+      TEMP_CURRENCY_ID,
+      200 * ONE_TEMP,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      EXTRINSIC_HASH_0,
       false,
       SwapType::Limit,
       // 2% slippage tolerance
@@ -152,15 +189,15 @@ pub fn confirm_swap_partial_filling() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Tifi, &2u64),
+      Adapter::balance_on_hold(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
       bob_initial_trade
         // add 0.2% fee
         .saturating_add(FeeAmount::get() * bob_initial_trade)
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Tifi, &2u64, true),
-      bob_initial_balance
+      Adapter::reducible_balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID, true),
+      BOB_INITIAL_BALANCE
         // reduce 2% slippage
         .saturating_sub(bob_initial_trade)
         // reduce 0.2% network fee
@@ -168,19 +205,14 @@ pub fn confirm_swap_partial_filling() {
     );
 
     // CHARLIE (MM): 4000 TEMP FOR 200 TIFI
-    let charlie_initial_trade: Balance = 400_000;
-
     let (trade_request_mm_id, trade_request_mm) = Oracle::add_new_swap_in_queue(
-      3u64,
-      CurrencyId::Wrapped(temp_asset_id),
-      charlie_initial_trade,
+      CHARLIE_ACCOUNT_ID,
+      TEMP_CURRENCY_ID,
+      CHARLIE_INITIAL_TRADE,
       CurrencyId::Tifi,
-      200_000_000_000_000,
+      200 * ONE_TIFI,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1,
-      ],
+      EXTRINSIC_HASH_1,
       true,
       SwapType::Limit,
       // 4% slippage tolerance
@@ -189,56 +221,53 @@ pub fn confirm_swap_partial_filling() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &3u64),
-      charlie_initial_trade
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID),
+      CHARLIE_INITIAL_TRADE
         // add 0.1% fee
-        .saturating_add(MarketMakerFeeAmount::get() * charlie_initial_trade)
+        .saturating_add(MarketMakerFeeAmount::get() * CHARLIE_INITIAL_TRADE)
     );
 
-    let last_charlie_balance = charlie_initial_wrapped_balance
-      .saturating_sub(charlie_initial_trade)
-      .saturating_sub(MarketMakerFeeAmount::get() * charlie_initial_trade);
+    let last_charlie_balance = CHARLIE_INITIAL_WRAPPED_BALANCE
+      .saturating_sub(CHARLIE_INITIAL_TRADE)
+      .saturating_sub(MarketMakerFeeAmount::get() * CHARLIE_INITIAL_TRADE);
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &3u64),
+      Adapter::balance(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID),
       last_charlie_balance
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Wrapped(temp_asset_id), &3u64, true),
-      charlie_initial_wrapped_balance
+      Adapter::reducible_balance(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID, true),
+      CHARLIE_INITIAL_WRAPPED_BALANCE
         // keep-alive token
         .saturating_sub(1_u128)
         // slippage
-        .saturating_sub(charlie_initial_trade)
+        .saturating_sub(CHARLIE_INITIAL_TRADE)
         // fees
-        .saturating_sub(MarketMakerFeeAmount::get() * charlie_initial_trade)
+        .saturating_sub(MarketMakerFeeAmount::get() * CHARLIE_INITIAL_TRADE)
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Wrapped(temp_asset_id), &3u64, false),
-      // minted 1_000_000 on genesis (no keep-alive)
-      charlie_initial_wrapped_balance
+      Adapter::reducible_balance(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID, false),
+      // minted 10_000 TEMP on genesis (no keep-alive)
+      CHARLIE_INITIAL_WRAPPED_BALANCE
         // slippage
-        .saturating_sub(charlie_initial_trade)
+        .saturating_sub(CHARLIE_INITIAL_TRADE)
         // fees
-        .saturating_sub(MarketMakerFeeAmount::get() * charlie_initial_trade)
+        .saturating_sub(MarketMakerFeeAmount::get() * CHARLIE_INITIAL_TRADE)
     );
 
     // DAVE (MM): 8000 TEMP for 400 TIFI
-    let dave_initial_trade: Balance = 800_000;
+    let dave_initial_trade: Balance = 8_000 * ONE_TEMP;
 
     let (trade_request_mm2_id, trade_request_mm2) = Oracle::add_new_swap_in_queue(
-      4u64,
-      CurrencyId::Wrapped(temp_asset_id),
-      800_000,
+      DAVE_ACCOUNT_ID,
+      TEMP_CURRENCY_ID,
+      8_000 * ONE_TEMP,
       CurrencyId::Tifi,
-      400_000_000_000_000,
+      400 * ONE_TIFI,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2,
-      ],
+      EXTRINSIC_HASH_2,
       true,
       SwapType::Limit,
       // 5% slippage tolerance
@@ -247,7 +276,7 @@ pub fn confirm_swap_partial_filling() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &4u64),
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &DAVE_ACCOUNT_ID),
       dave_initial_trade
         // add 0.1% fee
         .saturating_add(MarketMakerFeeAmount::get() * dave_initial_trade)
@@ -276,21 +305,21 @@ pub fn confirm_swap_partial_filling() {
     assert_eq!(trade_request_mm2.block_number, 0);
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Tifi, &2u64),
-      20_000_000_000_000
+      Adapter::balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
+      20 * ONE_TIFI
     );
 
-    let partial_filling_amount_charlie: Balance = 10_000;
+    let partial_filling_amount_charlie: Balance = 100 * ONE_TEMP;
     // partial filling
     assert_ok!(Oracle::confirm_swap(
-      alice.clone(),
+      context.alice.clone(),
       trade_request_id,
       vec![
         // charlie
         SwapConfirmation {
           request_id: trade_request_mm_id,
           // 5 tifi
-          amount_to_receive: 5_000_000_000_000,
+          amount_to_receive: 5 * ONE_TIFI,
           // 100 TEMP
           amount_to_send: partial_filling_amount_charlie,
         },
@@ -298,49 +327,43 @@ pub fn confirm_swap_partial_filling() {
     ));
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Tifi, &2u64),
-      bob_initial_balance
+      Adapter::balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
+      BOB_INITIAL_BALANCE
         // reduce 2% slippage
-        .saturating_sub(5_000_000_000_000)
+        .saturating_sub(5 * ONE_TIFI)
         // reduce 0.2% network fee
-        .saturating_sub(FeeAmount::get() * 5_000_000_000_000)
+        .saturating_sub(FeeAmount::get() * (5 * ONE_TIFI))
     );
 
     // swap confirmation for bob (user)
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_id,
       status: SwapStatus::PartiallyFilled,
-      account_id: 2u64,
+      account_id: BOB_ACCOUNT_ID,
       currency_from: CurrencyId::Tifi,
-      currency_amount_from: 5_000_000_000_000,
-      currency_to: CurrencyId::Wrapped(temp_asset_id),
+      currency_amount_from: 5 * ONE_TIFI,
+      currency_to: TEMP_CURRENCY_ID,
       currency_amount_to: partial_filling_amount_charlie,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      initial_extrinsic_hash: EXTRINSIC_HASH_0,
     }));
 
     // swap confirmation for charlie (mm)
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_mm_id,
       status: SwapStatus::PartiallyFilled,
-      account_id: 3u64,
-      currency_from: CurrencyId::Wrapped(temp_asset_id),
+      account_id: CHARLIE_ACCOUNT_ID,
+      currency_from: TEMP_CURRENCY_ID,
       currency_amount_from: partial_filling_amount_charlie,
       currency_to: CurrencyId::Tifi,
-      currency_amount_to: 5_000_000_000_000,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1,
-      ],
+      currency_amount_to: 5 * ONE_TIFI,
+      initial_extrinsic_hash: EXTRINSIC_HASH_1,
     }));
 
     // BOB: make sure the CLIENT current trade is partially filled and correctly updated
     let trade_request_filled = Oracle::swaps(trade_request_id).unwrap();
     assert_eq!(trade_request_filled.status, SwapStatus::PartiallyFilled);
 
-    let trade_request_account = Oracle::account_swaps(2u64).unwrap();
+    let trade_request_account = Oracle::account_swaps(BOB_ACCOUNT_ID).unwrap();
     assert_eq!(
       trade_request_account
         .iter()
@@ -349,7 +372,7 @@ pub fn confirm_swap_partial_filling() {
     );
 
     // 5 tifi
-    assert_eq!(trade_request_filled.amount_from_filled, 5_000_000_000_000);
+    assert_eq!(trade_request_filled.amount_from_filled, 5 * ONE_TIFI);
     // 100 TEMP
     assert_eq!(
       trade_request_filled.amount_to_filled,
@@ -365,18 +388,18 @@ pub fn confirm_swap_partial_filling() {
       partial_filling_amount_charlie
     );
     // 5 tifi
-    assert_eq!(trade_request_filled.amount_to_filled, 5_000_000_000_000);
+    assert_eq!(trade_request_filled.amount_to_filled, 5 * ONE_TIFI);
 
     // another partial filling who should close the trade
     assert_ok!(Oracle::confirm_swap(
-      alice.clone(),
+      context.alice.clone(),
       trade_request_id,
       vec![
         // dave
         SwapConfirmation {
           request_id: trade_request_mm2_id,
           // 5 tifi
-          amount_to_receive: 5_000_000_000_000,
+          amount_to_receive: 5 * ONE_TIFI,
           // 100 TEMP
           amount_to_send: partial_filling_amount_charlie,
         },
@@ -384,46 +407,40 @@ pub fn confirm_swap_partial_filling() {
     ));
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Tifi, &2u64),
-      bob_initial_balance
-        .saturating_sub(10_000_000_000_000)
+      Adapter::balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
+      BOB_INITIAL_BALANCE
+        .saturating_sub(10 * ONE_TIFI)
         // reduce 0.2% network fee
-        .saturating_sub(FeeAmount::get() * 10_000_000_000_000)
+        .saturating_sub(FeeAmount::get() * (10 * ONE_TIFI))
     );
 
     // swap confirmation for bob (user)
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_id,
       status: SwapStatus::Completed,
-      account_id: 2u64,
+      account_id: BOB_ACCOUNT_ID,
       currency_from: CurrencyId::Tifi,
-      currency_amount_from: 5_000_000_000_000,
-      currency_to: CurrencyId::Wrapped(temp_asset_id),
+      currency_amount_from: 5 * ONE_TIFI,
+      currency_to: TEMP_CURRENCY_ID,
       currency_amount_to: partial_filling_amount_charlie,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      initial_extrinsic_hash: EXTRINSIC_HASH_0,
     }));
 
     // swap confirmation for dave (second mm)
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_mm2_id,
       status: SwapStatus::PartiallyFilled,
-      account_id: 4u64,
-      currency_from: CurrencyId::Wrapped(temp_asset_id),
+      account_id: DAVE_ACCOUNT_ID,
+      currency_from: TEMP_CURRENCY_ID,
       currency_amount_from: partial_filling_amount_charlie,
       currency_to: CurrencyId::Tifi,
-      currency_amount_to: 5_000_000_000_000,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2,
-      ],
+      currency_amount_to: 5 * ONE_TIFI,
+      initial_extrinsic_hash: EXTRINSIC_HASH_2,
     }));
 
     // BOB: make sure the CLIENT current trade is deleted
     assert!(Oracle::swaps(trade_request_id).is_none());
-    let trade_request_account = Oracle::account_swaps(2u64).unwrap();
+    let trade_request_account = Oracle::account_swaps(BOB_ACCOUNT_ID).unwrap();
     assert_eq!(
       trade_request_account
         .iter()
@@ -434,7 +451,7 @@ pub fn confirm_swap_partial_filling() {
     // cant send another trade confirmation as the request should be deleted
     // we do expect `InvalidRequestId`
     assert_noop!(
-      Oracle::confirm_swap(alice.clone(), trade_request_id, vec![],),
+      Oracle::confirm_swap(context.alice.clone(), trade_request_id, vec![],),
       Error::<Test>::InvalidRequestId
     );
 
@@ -442,64 +459,67 @@ pub fn confirm_swap_partial_filling() {
     let trade_request_filled = Oracle::swaps(trade_request_mm2_id).unwrap();
     assert_eq!(trade_request_filled.status, SwapStatus::PartiallyFilled);
     // 100 TEMP
-    assert_eq!(trade_request_filled.amount_from_filled, 10_000);
+    assert_eq!(trade_request_filled.amount_from_filled, 100 * ONE_TEMP);
     // 5 tifi
-    assert_eq!(trade_request_filled.amount_to_filled, 5_000_000_000_000);
+    assert_eq!(trade_request_filled.amount_to_filled, 5 * ONE_TIFI);
 
     // cancel our mm's swap to release the funds
-    assert_ok!(Oracle::cancel_swap(alice.clone(), trade_request_mm_id,));
-    assert_ok!(Oracle::cancel_swap(alice, trade_request_mm2_id,));
+    assert_ok!(Oracle::cancel_swap(
+      context.alice.clone(),
+      trade_request_mm_id,
+    ));
+    assert_ok!(Oracle::cancel_swap(context.alice, trade_request_mm2_id,));
 
     // validate all balance
     assert_eq!(
-      Adapter::balance(CurrencyId::Tifi, &2u64),
-      bob_initial_balance
-        .saturating_sub(10_000_000_000_000)
+      Adapter::balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
+      BOB_INITIAL_BALANCE
+        .saturating_sub(10 * ONE_TIFI)
         // reduce 0.2% network fee
-        .saturating_sub(FeeAmount::get() * 10_000_000_000_000)
+        .saturating_sub(FeeAmount::get() * (10 * ONE_TIFI))
     );
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &2u64),
-      20_000
+      Adapter::balance(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
+      200 * ONE_TEMP
     );
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Tifi, &2u64),
+      Adapter::balance_on_hold(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
       Zero::zero()
     );
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Tifi, &3u64),
+      Adapter::balance(CurrencyId::Tifi, &CHARLIE_ACCOUNT_ID),
       // swap + initial balance
-      5_000_000_000_000 + 1_000_000_000_000
+      5 * ONE_TIFI + ONE_TIFI
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Wrapped(temp_asset_id), &3u64, false),
-      charlie_initial_wrapped_balance
+      Adapter::reducible_balance(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID, false),
+      CHARLIE_INITIAL_WRAPPED_BALANCE
         .saturating_sub(partial_filling_amount_charlie)
         .saturating_sub(MarketMakerFeeAmount::get() * partial_filling_amount_charlie)
     );
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &3u64),
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &CHARLIE_ACCOUNT_ID),
       Zero::zero()
     );
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Tifi, &4u64),
+      Adapter::balance(CurrencyId::Tifi, &DAVE_ACCOUNT_ID),
       // swap + initial balance
-      5_000_000_000_000 + 1_000_000_000_000
+      5 * ONE_TIFI + ONE_TIFI
     );
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &4u64),
-      dave_initial_wrapped_balance
+      Adapter::balance(TEMP_CURRENCY_ID, &DAVE_ACCOUNT_ID),
+      DAVE_INITIAL_WRAPPED_BALANCE
         .saturating_sub(partial_filling_amount_charlie)
         .saturating_sub(MarketMakerFeeAmount::get() * partial_filling_amount_charlie)
     );
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &4u64),
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &DAVE_ACCOUNT_ID),
       Zero::zero()
     );
   });
@@ -508,76 +528,29 @@ pub fn confirm_swap_partial_filling() {
 #[test]
 pub fn confirm_swap_with_fees() {
   new_test_ext().execute_with(|| {
-    let alice = Origin::signed(1u64);
+    let context = Context::default()
+      .set_oracle_status(true)
+      .mint_tifi(ALICE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(CHARLIE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(DAVE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(BOB_ACCOUNT_ID, 20 * ONE_TIFI)
+      .create_temp_asset_and_metadata()
+      .mint_temp(CHARLIE_ACCOUNT_ID, 10_000 * ONE_TEMP)
+      .mint_temp(DAVE_ACCOUNT_ID, 10_000 * ONE_TEMP);
 
-    let temp_asset_id = 4;
-
-    assert_ok!(Oracle::set_status(alice.clone(), true));
-    assert!(Oracle::status());
     Fees::start_era();
     assert!(!Fees::active_era().is_none());
     let current_era = Fees::active_era().unwrap().index;
 
-    // add 1 tifi to alice & mm
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &1u64,
-      1_000_000_000_000
-    ));
-
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &3u64,
-      1_000_000_000_000
-    ));
-
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &4u64,
-      1_000_000_000_000
-    ));
-
-    // add 20 tides to bob
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &2u64,
-      20_000_000_000_000
-    ));
-
-    // create TEMP asset
-    assert_ok!(Assets::force_create(
-      Origin::root(),
-      temp_asset_id,
-      1u64,
-      true,
-      1
-    ));
-
-    // make TEMP asset as 2 decimals
-    assert_ok!(Assets::set_metadata(
-      alice.clone(),
-      temp_asset_id,
-      "TEMP".into(),
-      "TEMP".into(),
-      2
-    ));
-
-    // mint TEMP funds to the MMs
-    assert_ok!(Assets::mint(alice.clone(), temp_asset_id, 3u64, 1_000_000));
-    assert_ok!(Assets::mint(alice.clone(), temp_asset_id, 4u64, 1_000_000));
-
     // BOB: 10 TIFI for 200 TEMP (20 TEMP/TIFI)
     let (trade_request_id, trade_request) = Oracle::add_new_swap_in_queue(
-      2u64,
+      BOB_ACCOUNT_ID,
       CurrencyId::Tifi,
-      10_000_000_000_000,
-      CurrencyId::Wrapped(temp_asset_id),
-      20_000,
+      10 * ONE_TIFI,
+      TEMP_CURRENCY_ID,
+      200 * ONE_TEMP,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      EXTRINSIC_HASH_0,
       false,
       SwapType::Limit,
       // 2% slippage tolerance
@@ -587,16 +560,13 @@ pub fn confirm_swap_with_fees() {
 
     // CHARLIE (MM): 4000 TEMP FOR 200 TIFI
     let (trade_request_mm_id, trade_request_mm) = Oracle::add_new_swap_in_queue(
-      3u64,
-      CurrencyId::Wrapped(temp_asset_id),
-      400_000,
+      CHARLIE_ACCOUNT_ID,
+      TEMP_CURRENCY_ID,
+      4_000 * ONE_TEMP,
       CurrencyId::Tifi,
-      200_000_000_000_000,
+      200 * ONE_TIFI,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1,
-      ],
+      EXTRINSIC_HASH_1,
       true,
       SwapType::Limit,
       // 5% slippage tolerance
@@ -606,16 +576,13 @@ pub fn confirm_swap_with_fees() {
 
     // DAVE (MM): 100 TEMP for 5 TIFI
     let (trade_request_mm2_id, trade_request_mm2) = Oracle::add_new_swap_in_queue(
-      4u64,
-      CurrencyId::Wrapped(temp_asset_id),
-      10_000,
+      DAVE_ACCOUNT_ID,
+      TEMP_CURRENCY_ID,
+      100 * ONE_TEMP,
       CurrencyId::Tifi,
-      5_000_000_000_000,
+      5 * ONE_TIFI,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2,
-      ],
+      EXTRINSIC_HASH_2,
       true,
       SwapType::Limit,
       // 4% slippage tolerance
@@ -642,7 +609,7 @@ pub fn confirm_swap_with_fees() {
     assert_eq!(trade_request_mm2.status, SwapStatus::Pending);
 
     assert_eq!(
-      Oracle::account_swaps(2u64)
+      Oracle::account_swaps(BOB_ACCOUNT_ID)
         .unwrap()
         .iter()
         .find(|(request_id, _)| *request_id == trade_request_id),
@@ -650,7 +617,7 @@ pub fn confirm_swap_with_fees() {
     );
 
     assert_eq!(
-      Oracle::account_swaps(3u64)
+      Oracle::account_swaps(CHARLIE_ACCOUNT_ID)
         .unwrap()
         .iter()
         .find(|(request_id, _)| *request_id == trade_request_mm_id),
@@ -658,7 +625,7 @@ pub fn confirm_swap_with_fees() {
     );
 
     assert_eq!(
-      Oracle::account_swaps(4u64)
+      Oracle::account_swaps(DAVE_ACCOUNT_ID)
         .unwrap()
         .iter()
         .find(|(request_id, _)| *request_id == trade_request_mm2_id),
@@ -670,24 +637,24 @@ pub fn confirm_swap_with_fees() {
 
     // partial filling
     assert_ok!(Oracle::confirm_swap(
-      alice,
+      context.alice,
       trade_request_id,
       vec![
         // charlie
         SwapConfirmation {
           request_id: trade_request_mm_id,
           // 5 tifi
-          amount_to_receive: 5_000_000_000_000,
+          amount_to_receive: 5 * ONE_TIFI,
           // 100 TEMP
-          amount_to_send: 10_000,
+          amount_to_send: 100 * ONE_TEMP,
         },
         // dave
         SwapConfirmation {
           request_id: trade_request_mm2_id,
           // 5 tifi
-          amount_to_receive: 5_000_000_000_000,
+          amount_to_receive: 5 * ONE_TIFI,
           // 100 TEMP
-          amount_to_send: 10_000,
+          amount_to_send: 100 * ONE_TEMP,
         },
       ],
     ));
@@ -696,30 +663,24 @@ pub fn confirm_swap_with_fees() {
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_id,
       status: SwapStatus::Completed,
-      account_id: 2u64,
+      account_id: BOB_ACCOUNT_ID,
       currency_from: CurrencyId::Tifi,
-      currency_amount_from: 10_000_000_000_000,
-      currency_to: CurrencyId::Wrapped(temp_asset_id),
-      currency_amount_to: 20_000,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      currency_amount_from: 10 * ONE_TIFI,
+      currency_to: TEMP_CURRENCY_ID,
+      currency_amount_to: 200 * ONE_TEMP,
+      initial_extrinsic_hash: EXTRINSIC_HASH_0,
     }));
 
     // swap confirmation for charlie (mm1)
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_mm_id,
       status: SwapStatus::PartiallyFilled,
-      account_id: 3u64,
-      currency_from: CurrencyId::Wrapped(temp_asset_id),
-      currency_amount_from: 10_000,
+      account_id: CHARLIE_ACCOUNT_ID,
+      currency_from: TEMP_CURRENCY_ID,
+      currency_amount_from: 100 * ONE_TEMP,
       currency_to: CurrencyId::Tifi,
-      currency_amount_to: 5_000_000_000_000,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1,
-      ],
+      currency_amount_to: 5 * ONE_TIFI,
+      initial_extrinsic_hash: EXTRINSIC_HASH_1,
     }));
 
     // swap confirmation for dave (mm2)
@@ -727,21 +688,18 @@ pub fn confirm_swap_with_fees() {
     System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
       request_id: trade_request_mm2_id,
       status: SwapStatus::Completed,
-      account_id: 4u64,
-      currency_from: CurrencyId::Wrapped(temp_asset_id),
-      currency_amount_from: 10_000,
+      account_id: DAVE_ACCOUNT_ID,
+      currency_from: TEMP_CURRENCY_ID,
+      currency_amount_from: 100 * ONE_TEMP,
       currency_to: CurrencyId::Tifi,
-      currency_amount_to: 5_000_000_000_000,
-      initial_extrinsic_hash: [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2,
-      ],
+      currency_amount_to: 5 * ONE_TIFI,
+      initial_extrinsic_hash: EXTRINSIC_HASH_2,
     }));
 
     // BOB: make sure the CLIENT current trade is deleted
     assert!(Oracle::swaps(trade_request_id).is_none());
     assert_eq!(
-      Oracle::account_swaps(2u64)
+      Oracle::account_swaps(BOB_ACCOUNT_ID)
         .unwrap()
         .iter()
         .find(|(request_id, _)| *request_id == trade_request_id),
@@ -750,7 +708,7 @@ pub fn confirm_swap_with_fees() {
 
     // CHARLIE: make sure the MM current trade is partially filled and correctly updated
     assert_eq!(
-      Oracle::account_swaps(3u64)
+      Oracle::account_swaps(CHARLIE_ACCOUNT_ID)
         .unwrap()
         .iter()
         .find(|(request_id, _)| *request_id == trade_request_mm_id),
@@ -760,14 +718,14 @@ pub fn confirm_swap_with_fees() {
     let trade_request_filled = Oracle::swaps(trade_request_mm_id).unwrap();
     assert_eq!(trade_request_filled.status, SwapStatus::PartiallyFilled);
     // 100 TEMP
-    assert_eq!(trade_request_filled.amount_from_filled, 10_000);
+    assert_eq!(trade_request_filled.amount_from_filled, 100 * ONE_TEMP);
     // 5 tifi
-    assert_eq!(trade_request_filled.amount_to_filled, 5_000_000_000_000);
+    assert_eq!(trade_request_filled.amount_to_filled, 5 * ONE_TIFI);
 
     // DAVE: make sure the MM current trade is totally filled (deleted)
     assert!(Oracle::swaps(trade_request_mm2_id).is_none());
     assert_eq!(
-      Oracle::account_swaps(4u64)
+      Oracle::account_swaps(DAVE_ACCOUNT_ID)
         .unwrap()
         .iter()
         .find(|(request_id, _)| *request_id == trade_request_mm2_id),
@@ -778,33 +736,36 @@ pub fn confirm_swap_with_fees() {
     assert_eq!(
       Adapter::balance(CurrencyId::Tifi, &Fees::account_id()),
       // we burned 1 tifi on start so it should contain 1.2 tifi now
-      1_200_000_000_000
+      1_200 * ONE_MILLI_TIFI
     );
 
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &Fees::account_id()),
-      200
+      Adapter::balance(TEMP_CURRENCY_ID, &Fees::account_id()),
+      2 * ONE_TEMP
     );
 
     // BOB Should have 9.8 tifi remaining (started with 20), sent 10 tifi and paid 2% fees
-    assert_eq!(Adapter::balance(CurrencyId::Tifi, &2u64), 9_800_000_000_000);
+    assert_eq!(
+      Adapter::balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
+      9_800 * ONE_MILLI_TIFI
+    );
 
     // BOB Should have 200 TEMP
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &2u64),
-      20_000
+      Adapter::balance(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
+      200 * ONE_TEMP
     );
 
     // make sure fees are registered on chain
-    let bob_fee = Fees::account_fees(current_era, 2u64);
-    assert_eq!(bob_fee.first().unwrap().1.fee, 200_000_000_000);
-    assert_eq!(bob_fee.first().unwrap().1.amount, 10_000_000_000_000);
+    let bob_fee = Fees::account_fees(current_era, BOB_ACCOUNT_ID);
+    assert_eq!(bob_fee.first().unwrap().1.fee, 200 * ONE_MILLI_TIFI);
+    assert_eq!(bob_fee.first().unwrap().1.amount, 10 * ONE_TIFI);
 
-    let charlie_fee = Fees::account_fees(current_era, 3u64);
+    let charlie_fee = Fees::account_fees(current_era, CHARLIE_ACCOUNT_ID);
     assert_eq!(charlie_fee.first().unwrap().1.fee, 100);
     assert_eq!(charlie_fee.first().unwrap().1.amount, 10_000);
 
-    let dave_fee = Fees::account_fees(current_era, 4u64);
+    let dave_fee = Fees::account_fees(current_era, DAVE_ACCOUNT_ID);
     assert_eq!(dave_fee.first().unwrap().1.fee, 100);
     assert_eq!(dave_fee.first().unwrap().1.amount, 10_000);
   });
@@ -813,75 +774,34 @@ pub fn confirm_swap_with_fees() {
 #[test]
 pub fn confirm_swap_ourself() {
   new_test_ext().execute_with(|| {
-    let alice = Origin::signed(1u64);
+    const BOB_INITIAL_BALANCE: Balance = 20 * ONE_TIFI;
+    const BOB_INITIAL_WRAPPED_BALANCE: Balance = 10_000 * ONE_TEMP;
 
-    let temp_asset_id = 4;
-
-    let bob_initial_balance: Balance = 20_000_000_000_000;
-    let bob_initial_wrapped_balance: Balance = 1_000_000;
-
-    assert_ok!(Oracle::set_status(alice.clone(), true));
-    assert!(Oracle::status());
-
-    // add 1 tifi to alice & all MMs
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &1u64,
-      1_000_000_000_000
-    ));
-
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &2u64,
-      bob_initial_balance
-    ));
-
-    // create TEMP asset
-    assert_ok!(Assets::force_create(
-      Origin::root(),
-      temp_asset_id,
-      1u64,
-      true,
-      1
-    ));
+    let context = Context::default()
+      .set_oracle_status(true)
+      .mint_tifi(ALICE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(BOB_ACCOUNT_ID, BOB_INITIAL_BALANCE)
+      .create_temp_asset_and_metadata()
+      .mint_temp(BOB_ACCOUNT_ID, BOB_INITIAL_WRAPPED_BALANCE);
 
     assert_eq!(Fees::account_id(), 8246216774960574317);
 
-    // make TEMP asset as 2 decimals
-    assert_ok!(Assets::set_metadata(
-      alice.clone(),
-      temp_asset_id,
-      "TEMP".into(),
-      "TEMP".into(),
-      2
-    ));
-
-    // mint TEMP funds to the MMs
-    assert_ok!(Assets::mint(
-      alice.clone(),
-      temp_asset_id,
-      2u64,
-      bob_initial_wrapped_balance
-    ));
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &2u64),
-      bob_initial_wrapped_balance
+      Adapter::balance(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
+      BOB_INITIAL_WRAPPED_BALANCE
     );
 
     // BOB: 10 TIFI for 200 TEMP (20 TEMP/TIFI)
-    let bob_initial_trade: Balance = 10_000_000_000_000;
+    let bob_initial_trade: Balance = 10 * ONE_TIFI;
 
     let (trade_request_id, trade_request) = Oracle::add_new_swap_in_queue(
-      2u64,
+      BOB_ACCOUNT_ID,
       CurrencyId::Tifi,
       bob_initial_trade,
-      CurrencyId::Wrapped(temp_asset_id),
-      40_000,
+      TEMP_CURRENCY_ID,
+      400 * ONE_TEMP,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      EXTRINSIC_HASH_0,
       false,
       SwapType::Limit,
       // 2% slippage tolerance
@@ -890,34 +810,31 @@ pub fn confirm_swap_ourself() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Tifi, &2u64),
+      Adapter::balance_on_hold(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
       bob_initial_trade
         // add 0.2% fee
         .saturating_add(FeeAmount::get() * bob_initial_trade)
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Tifi, &2u64, true),
-      bob_initial_balance
+      Adapter::reducible_balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID, true),
+      BOB_INITIAL_BALANCE
         // reduce 2% slippage
         .saturating_sub(bob_initial_trade)
         // reduce 0.2% network fee
         .saturating_sub(FeeAmount::get() * bob_initial_trade)
     );
 
-    let bob_initial_trade: Balance = 40_000;
+    let bob_initial_trade: Balance = 400 * ONE_TEMP;
 
     let (trade_request_mm_id, trade_request_mm) = Oracle::add_new_swap_in_queue(
-      2u64,
-      CurrencyId::Wrapped(temp_asset_id),
+      BOB_ACCOUNT_ID,
+      TEMP_CURRENCY_ID,
       bob_initial_trade,
       CurrencyId::Tifi,
-      10_000_000_000_000,
+      10 * ONE_TIFI,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      EXTRINSIC_HASH_0,
       true,
       SwapType::Limit,
       // 5% slippage tolerance
@@ -926,7 +843,7 @@ pub fn confirm_swap_ourself() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &2u64),
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
       bob_initial_trade
         // add 0.1% fee
         .saturating_add(MarketMakerFeeAmount::get() * bob_initial_trade)
@@ -954,14 +871,14 @@ pub fn confirm_swap_ourself() {
 
     // partial filling
     assert_ok!(Oracle::confirm_swap(
-      alice.clone(),
+      context.alice.clone(),
       trade_request_id,
       vec![
         // charlie
         SwapConfirmation {
           request_id: trade_request_mm_id,
-          amount_to_receive: 10_000_000_000_000,
-          amount_to_send: 40_000,
+          amount_to_receive: 10 * ONE_TIFI,
+          amount_to_send: 400 * ONE_TEMP,
         },
       ],
     ));
@@ -973,28 +890,28 @@ pub fn confirm_swap_ourself() {
     // cant send another trade confirmation as the request should be deleted
     // we do expect `InvalidRequestId`
     assert_noop!(
-      Oracle::confirm_swap(alice, trade_request_id, vec![],),
+      Oracle::confirm_swap(context.alice, trade_request_id, vec![],),
       Error::<Test>::InvalidRequestId
     );
 
     // validate all balance
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Tifi, &2u64, false),
+      Adapter::reducible_balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID, false),
       // we should refund the extra fees paid on the slippage value
-      bob_initial_balance.saturating_sub(FeeAmount::get() * 10_000_000_000_000)
+      BOB_INITIAL_BALANCE.saturating_sub(FeeAmount::get() * (10 * ONE_TIFI))
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Wrapped(temp_asset_id), &2u64, false),
-      bob_initial_wrapped_balance.saturating_sub(MarketMakerFeeAmount::get() * 40_000)
+      Adapter::reducible_balance(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID, false),
+      BOB_INITIAL_WRAPPED_BALANCE.saturating_sub(MarketMakerFeeAmount::get() * (400 * ONE_TEMP))
     );
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Tifi, &2u64),
+      Adapter::balance_on_hold(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
       Zero::zero()
     );
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &2u64),
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
       Zero::zero()
     );
   });
@@ -1003,75 +920,34 @@ pub fn confirm_swap_ourself() {
 #[test]
 pub fn test_slippage() {
   new_test_ext().execute_with(|| {
-    let alice = Origin::signed(1u64);
+    const BOB_INITIAL_BALANCE: Balance = 20 * ONE_TIFI;
+    const BOB_INITIAL_WRAPPED_BALANCE: Balance = 10_000 * ONE_TEMP;
 
-    let temp_asset_id = 4;
-
-    let bob_initial_balance: Balance = 20_000_000_000_000;
-    let bob_initial_wrapped_balance: Balance = 1_000_000;
-
-    assert_ok!(Oracle::set_status(alice.clone(), true));
-    assert!(Oracle::status());
-
-    // add 1 tifi to alice & all MMs
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &1u64,
-      1_000_000_000_000
-    ));
-
-    assert_ok!(Adapter::mint_into(
-      CurrencyId::Tifi,
-      &2u64,
-      bob_initial_balance
-    ));
-
-    // create TEMP asset
-    assert_ok!(Assets::force_create(
-      Origin::root(),
-      temp_asset_id,
-      1u64,
-      true,
-      1
-    ));
+    let context = Context::default()
+      .set_oracle_status(true)
+      .mint_tifi(ALICE_ACCOUNT_ID, ONE_TIFI)
+      .mint_tifi(BOB_ACCOUNT_ID, BOB_INITIAL_BALANCE)
+      .create_temp_asset_and_metadata()
+      .mint_temp(BOB_ACCOUNT_ID, BOB_INITIAL_WRAPPED_BALANCE);
 
     assert_eq!(Fees::account_id(), 8246216774960574317);
 
-    // make TEMP asset as 2 decimals
-    assert_ok!(Assets::set_metadata(
-      alice.clone(),
-      temp_asset_id,
-      "TEMP".into(),
-      "TEMP".into(),
-      2
-    ));
-
-    // mint TEMP funds to the MMs
-    assert_ok!(Assets::mint(
-      alice.clone(),
-      temp_asset_id,
-      2u64,
-      bob_initial_wrapped_balance
-    ));
     assert_eq!(
-      Adapter::balance(CurrencyId::Wrapped(temp_asset_id), &2u64),
-      bob_initial_wrapped_balance
+      Adapter::balance(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
+      BOB_INITIAL_WRAPPED_BALANCE
     );
 
     // BOB: 10 TIFI for 200 TEMP (20 TEMP/TIFI)
-    let bob_initial_trade: Balance = 10_000_000_000_000;
+    let bob_initial_trade: Balance = 10 * ONE_TIFI;
 
     let (trade_request_id, trade_request) = Oracle::add_new_swap_in_queue(
-      2u64,
+      BOB_ACCOUNT_ID,
       CurrencyId::Tifi,
       bob_initial_trade,
-      CurrencyId::Wrapped(temp_asset_id),
-      40_000,
+      TEMP_CURRENCY_ID,
+      400 * ONE_TEMP,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      EXTRINSIC_HASH_0,
       false,
       SwapType::Market,
       // 2% slippage tolerance
@@ -1080,15 +956,15 @@ pub fn test_slippage() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Tifi, &2u64),
+      Adapter::balance_on_hold(CurrencyId::Tifi, &BOB_ACCOUNT_ID),
       bob_initial_trade
         // add 0.2% fee
         .saturating_add(FeeAmount::get() * bob_initial_trade)
     );
 
     assert_eq!(
-      Adapter::reducible_balance(CurrencyId::Tifi, &2u64, true),
-      bob_initial_balance
+      Adapter::reducible_balance(CurrencyId::Tifi, &BOB_ACCOUNT_ID, true),
+      BOB_INITIAL_BALANCE
         // reduce 2% slippage
         .saturating_sub(bob_initial_trade)
         // reduce 0.2% network fee
@@ -1096,17 +972,14 @@ pub fn test_slippage() {
     );
 
     let (trade_request_mm_id, trade_request_mm) = Oracle::add_new_swap_in_queue(
-      2u64,
-      CurrencyId::Wrapped(temp_asset_id),
+      BOB_ACCOUNT_ID,
+      TEMP_CURRENCY_ID,
       // ratio is a bit different (mm is willing to pay a bit more for the same amount)
-      50_000,
+      500 * ONE_TEMP,
       CurrencyId::Tifi,
       bob_initial_trade,
       0,
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-      ],
+      EXTRINSIC_HASH_0,
       true,
       SwapType::Limit,
       Permill::from_percent(0),
@@ -1114,10 +987,10 @@ pub fn test_slippage() {
     .unwrap();
 
     assert_eq!(
-      Adapter::balance_on_hold(CurrencyId::Wrapped(temp_asset_id), &2u64),
-      50_000_u128
+      Adapter::balance_on_hold(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
+      (500 * ONE_TEMP)
         // add 0.1% fee
-        .saturating_add(MarketMakerFeeAmount::get() * 50_000_u128)
+        .saturating_add(MarketMakerFeeAmount::get() * (500 * ONE_TEMP))
     );
 
     // make sure our trade request is created correctly
@@ -1142,12 +1015,12 @@ pub fn test_slippage() {
 
     assert_noop!(
       Oracle::confirm_swap(
-        alice.clone(),
+        context.alice.clone(),
         trade_request_id,
         vec![SwapConfirmation {
           request_id: trade_request_mm_id,
-          amount_to_receive: 8_000_000_000_000,
-          amount_to_send: 40_000,
+          amount_to_receive: 8 * ONE_TIFI,
+          amount_to_send: 400 * ONE_TEMP,
         },],
       ),
       Error::<Test>::Overflow
@@ -1155,13 +1028,13 @@ pub fn test_slippage() {
 
     // partial filling
     assert_ok!(Oracle::confirm_swap(
-      alice.clone(),
+      context.alice.clone(),
       trade_request_id,
       vec![SwapConfirmation {
         request_id: trade_request_mm_id,
         // 9.8 test token (within the 2% slippage of the initial request)
-        amount_to_receive: 9_800_000_000_000,
-        amount_to_send: 40_000,
+        amount_to_receive: 9_800 * ONE_MILLI_TIFI,
+        amount_to_send: 400 * ONE_TEMP,
       },],
     ));
 


### PR DESCRIPTION
* Extracted a common Context struct and implemented common functions, so we can reuse its functions in chain for test arrangements.
* Replaced hard coded extrinsic hash byte arrays with constants.
* Replaced hard coded magic numbers with constants for both TIFI and TEMP amounts.
* Replaced hard coded strings with constants.
