### PR TITLE
Quorum prevent multiple vote same member

### DIFF
--- a/frame/quorum/src/lib.rs
+++ b/frame/quorum/src/lib.rs
@@ -714,7 +714,7 @@ pub mod pallet {
       );
       ensure!(votes.expiry >= current_block, Error::<T>::ProposalExpired);
       ensure!(
-        !votes.votes_for.contains(&who) || !votes.votes_against.contains(&who),
+        !votes.votes_for.contains(&who) && !votes.votes_against.contains(&who),
         Error::<T>::MemberAlreadyVoted
       );
 


### PR DESCRIPTION
When commit a new vote, it should make sure it's stored in neither votes_for nor votes_against. Otherwise 2 votes with different opinion for a proposal by the same member can be both counted. 