### PR TITLE
Fixed adding account watch list

### DIFF
--- a/frame/quorum/src/lib.rs
+++ b/frame/quorum/src/lib.rs
@@ -975,24 +975,39 @@ pub mod pallet {
         transaction_id: transaction_id.clone(),
       };
 
-      AccountWatchList::<T>::try_mutate_exists(account_id, |account_watch_list| {
-        match account_watch_list {
-          Some(current_watch_list) => current_watch_list
-            .try_push(watch_list)
-            .map_err(|_| Error::<T>::WatchlistOverflow),
-          None => {
-            let empty_bounded_vec: BoundedVec<
-              WatchList<T::BlockNumber, BoundedVec<u8, <T as pallet::Config>::StringLimit>>,
-              <T as pallet::Config>::WatchListLimit,
-            > = vec![watch_list]
-              .try_into()
-              .map_err(|_| Error::<T>::UnknownError)?;
-
-            AccountWatchList::<T>::insert(account_id, empty_bounded_vec);
-            Ok(())
+      if AccountWatchList::<T>::contains_key(account_id) {
+        let mut watch_list_for_account_id_is_none: bool = false;
+        AccountWatchList::<T>::try_mutate_exists(account_id, |account_watch_list| {
+          match account_watch_list {
+            Some(current_watch_list) => current_watch_list
+              .try_push(watch_list.clone())
+              .map_err(|_| Error::<T>::WatchlistOverflow),
+            None => {
+              watch_list_for_account_id_is_none = true;
+              Ok(())
+            }
           }
+        })?;
+
+        if watch_list_for_account_id_is_none {
+          AccountWatchList::<T>::mutate_exists(account_id, |account_watch_list| {
+            *account_watch_list = Some(
+              vec![watch_list]
+                .try_into()
+                .expect("Watch list should be created"),
+            );
+          })
         }
-      })?;
+      } else {
+        let empty_bounded_vec: BoundedVec<
+          WatchList<T::BlockNumber, BoundedVec<u8, <T as pallet::Config>::StringLimit>>,
+          <T as pallet::Config>::WatchListLimit,
+        > = vec![watch_list]
+          .try_into()
+          .expect("Watch list should be created");
+
+        AccountWatchList::<T>::insert(account_id, empty_bounded_vec);
+      }
 
       Self::deposit_event(Event::<T>::WatchTransactionAdded {
         account_id: account_id.clone(),

--- a/frame/quorum/src/lib.rs
+++ b/frame/quorum/src/lib.rs
@@ -975,7 +975,16 @@ pub mod pallet {
         transaction_id: transaction_id.clone(),
       };
 
-      if AccountWatchList::<T>::contains_key(account_id) {
+      if !AccountWatchList::<T>::contains_key(account_id) {
+        let empty_bounded_vec: BoundedVec<
+          WatchList<T::BlockNumber, BoundedVec<u8, <T as pallet::Config>::StringLimit>>,
+          <T as pallet::Config>::WatchListLimit,
+        > = vec![watch_list]
+          .try_into()
+          .expect("Watch list should be created");
+
+        AccountWatchList::<T>::insert(account_id, empty_bounded_vec);
+      } else {
         let mut watch_list_for_account_id_is_none: bool = false;
         AccountWatchList::<T>::try_mutate_exists(account_id, |account_watch_list| {
           match account_watch_list {
@@ -998,15 +1007,6 @@ pub mod pallet {
             );
           })
         }
-      } else {
-        let empty_bounded_vec: BoundedVec<
-          WatchList<T::BlockNumber, BoundedVec<u8, <T as pallet::Config>::StringLimit>>,
-          <T as pallet::Config>::WatchListLimit,
-        > = vec![watch_list]
-          .try_into()
-          .expect("Watch list should be created");
-
-        AccountWatchList::<T>::insert(account_id, empty_bounded_vec);
       }
 
       Self::deposit_event(Event::<T>::WatchTransactionAdded {


### PR DESCRIPTION
Instead of `insert` a new key-value pair, `assign` the watch list to the value for the account_id that is not found in the `account_watch_list` map.
By calling `insert` method to add a new key-value pair within a `try_mutate_exist` function of this map passes the compilation, but does not save the new key-value pair in the map. This is tested and proved in [PR-129](https://github.com/tidelabs/tidechain/pull/129)