### PR TITLE
Implement Sunrise pool leftover

### DIFF
--- a/frame/fees/src/mock.rs
+++ b/frame/fees/src/mock.rs
@@ -202,6 +202,8 @@ parameter_types! {
   pub const Cooldown: BlockNumber = 10;
   // max 10k rewards
   pub const MaximumRewardPerSwap: Balance = 10_000_000_000_000_000;
+  // 50%
+  pub const LeftoverSwapRebates: FixedU128 = FixedU128::from_inner(500_000_000_000_000_000);
 }
 
 impl pallet_sunrise::Config for Test {
@@ -211,6 +213,7 @@ impl pallet_sunrise::Config for Test {
   type CurrencyTidefi = Adapter<AccountId>;
   type Cooldown = Cooldown;
   type MaximumRewardPerSwap = MaximumRewardPerSwap;
+  type LeftoverSwapRebates = LeftoverSwapRebates;
 }
 
 impl pallet_fees::Config for Test {

--- a/frame/fees/src/tests.rs
+++ b/frame/fees/src/tests.rs
@@ -122,10 +122,8 @@ pub fn register_swap_fees() {
         .transactions_remaining,
       0
     );
-    assert_eq!(
-      Sunrise::sunrise_pools().first().unwrap().balance,
-      67_199_997_500_000_000_000
-    );
+    assert_eq!(Sunrise::sunrise_pools().first().unwrap().balance, 0);
+    assert_eq!(Sunrise::pools_left_over(), 67_199_997_499_999_000_000);
   });
 }
 

--- a/frame/oracle/src/mock.rs
+++ b/frame/oracle/src/mock.rs
@@ -33,7 +33,7 @@ use sp_core::H256;
 use sp_runtime::{
   testing::Header,
   traits::{BlakeTwo256, IdentityLookup},
-  DispatchError, DispatchResult, Permill,
+  DispatchError, DispatchResult, FixedU128, Permill,
 };
 use std::marker::PhantomData;
 use system::EnsureRoot;

--- a/frame/oracle/src/mock.rs
+++ b/frame/oracle/src/mock.rs
@@ -166,7 +166,8 @@ parameter_types! {
   pub const Cooldown: BlockNumber = 10;
   // max 10k rewards
   pub const MaximumRewardPerSwap: Balance = 10_000_000_000_000_000;
-
+  // 50%
+  pub const LeftoverSwapRebates: FixedU128 = FixedU128::from_inner(500_000_000_000_000_000);
 }
 
 impl pallet_oracle::Config for Test {
@@ -228,6 +229,7 @@ impl pallet_sunrise::Config for Test {
   type CurrencyTidefi = Adapter<AccountId>;
   type Cooldown = Cooldown;
   type MaximumRewardPerSwap = MaximumRewardPerSwap;
+  type LeftoverSwapRebates = LeftoverSwapRebates;
 }
 
 impl pallet_timestamp::Config for Test {

--- a/frame/quorum/src/mock.rs
+++ b/frame/quorum/src/mock.rs
@@ -33,7 +33,7 @@ use sp_core::H256;
 use sp_runtime::{
   testing::Header,
   traits::{BlakeTwo256, IdentityLookup},
-  DispatchError, DispatchResult,
+  DispatchError, DispatchResult, FixedU128,
 };
 use std::marker::PhantomData;
 use system::EnsureRoot;

--- a/frame/quorum/src/mock.rs
+++ b/frame/quorum/src/mock.rs
@@ -154,6 +154,8 @@ parameter_types! {
   pub const Cooldown: BlockNumber = 10;
   // max 10k rewards
   pub const MaximumRewardPerSwap: Balance = 10_000_000_000_000_000;
+  // 50%
+  pub const LeftoverSwapRebates: FixedU128 = FixedU128::from_inner(500_000_000_000_000_000);
 }
 
 impl pallet_quorum::Config for Test {
@@ -180,6 +182,7 @@ impl pallet_sunrise::Config for Test {
   type CurrencyTidefi = Adapter<AccountId>;
   type Cooldown = Cooldown;
   type MaximumRewardPerSwap = MaximumRewardPerSwap;
+  type LeftoverSwapRebates = LeftoverSwapRebates;
 }
 
 impl pallet_security::Config for Test {

--- a/frame/sunrise/src/lib.rs
+++ b/frame/sunrise/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
   pub enum Event<T: Config> {
     SunriseRewarded {
       era_index: EraIndex,
-      pool_id: u8,
+      pool_id: Option<u8>,
       account_id: T::AccountId,
       reward: Balance,
     },
@@ -238,7 +238,7 @@ pub mod pallet {
         .iter()
         // make sure there is enough transaction remaining in the pool
         .filter(|pool| pool.transactions_remaining > 0)
-        // make sure there is enough tifi remaining to fullfill this
+        // make sure there is enough tdfy's remaining to fullfill this
         .filter(|pool| {
           pool.balance > 0
             && pool.balance
@@ -415,7 +415,7 @@ pub mod pallet {
         // Emit event
         Self::deposit_event(Event::<T>::SunriseRewarded {
           era_index,
-          pool_id: sunrise_pool_available.id,
+          pool_id: Some(sunrise_pool_available.id),
           account_id: account_id.clone(),
           reward: real_fees_in_tide_with_rebates,
         });
@@ -441,7 +441,7 @@ pub mod pallet {
           // Emit event
           Self::deposit_event(Event::<T>::SunriseRewarded {
             era_index,
-            pool_id: 0,
+            pool_id: None,
             account_id: account_id.clone(),
             reward: real_fees_in_tide_with_rebates,
           });

--- a/frame/sunrise/src/lib.rs
+++ b/frame/sunrise/src/lib.rs
@@ -88,6 +88,10 @@ pub mod pallet {
     #[pallet::constant]
     type MaximumRewardPerSwap: Get<Balance>;
 
+    /// For each tier, leftover funds will be allocated to to this tier
+    #[pallet::constant]
+    type LeftoverSwapRebates: Get<FixedU128>;
+
     /// Security traits
     type Security: SecurityExt<Self::AccountId, Self::BlockNumber>;
 
@@ -106,6 +110,11 @@ pub mod pallet {
   #[pallet::storage]
   #[pallet::getter(fn sunrise_pools)]
   pub type Pools<T: Config> = StorageValue<_, BoundedPools, ValueQuery>;
+
+  /// The balance available as left-over from the pools.
+  #[pallet::storage]
+  #[pallet::getter(fn pools_left_over)]
+  pub type PoolsLeftOverBalance<T: Config> = StorageValue<_, Balance, ValueQuery>;
 
   /// The active onboarding rebates (gas refunds on-deposit)
   #[pallet::storage]
@@ -387,6 +396,14 @@ pub mod pallet {
           // Reduce number of transactions remaining for this pool
           sunrise_pool.transactions_remaining -= 1;
 
+          // we've reached the end of the pool, move the balance to the left-over pool
+          if sunrise_pool.transactions_remaining == 0 && sunrise_pool.balance > 0 {
+            PoolsLeftOverBalance::<T>::mutate(|left_over| {
+              *left_over = left_over.saturating_add(sunrise_pool.balance);
+            });
+            sunrise_pool.balance = 0;
+          }
+
           Ok(())
         })?;
 
@@ -405,7 +422,34 @@ pub mod pallet {
 
         Ok(Some(real_fees_in_tide_with_rebates))
       } else {
-        Ok(None)
+        // check if we have some leftover that can be used
+        let available_left_over = Self::pools_left_over();
+        let real_fees_in_tide_with_rebates =
+          Self::calculate_rebates_on_fees_paid(T::LeftoverSwapRebates::get(), &fee)?;
+
+        if available_left_over >= real_fees_in_tide_with_rebates {
+          // Increment reward for the account
+          Rewards::<T>::mutate(account_id.clone(), era_index, |rewards| {
+            *rewards = rewards.saturating_add(real_fees_in_tide_with_rebates);
+          });
+
+          // Reduce leftover
+          PoolsLeftOverBalance::<T>::mutate(|left_over| {
+            *left_over = left_over.saturating_sub(real_fees_in_tide_with_rebates);
+          });
+
+          // Emit event
+          Self::deposit_event(Event::<T>::SunriseRewarded {
+            era_index,
+            pool_id: 0,
+            account_id: account_id.clone(),
+            reward: real_fees_in_tide_with_rebates,
+          });
+
+          Ok(Some(real_fees_in_tide_with_rebates))
+        } else {
+          Ok(None)
+        }
       }
     }
 

--- a/frame/sunrise/src/mock.rs
+++ b/frame/sunrise/src/mock.rs
@@ -202,6 +202,8 @@ parameter_types! {
   pub const Cooldown: BlockNumber = 10;
   // max 10k rewards
   pub const MaximumRewardPerSwap: Balance = 10_000_000_000_000_000;
+  // 50%
+  pub const LeftoverSwapRebates: FixedU128 = FixedU128::from_inner(500_000_000_000_000_000);
 }
 
 impl pallet_sunrise::Config for Test {
@@ -211,6 +213,7 @@ impl pallet_sunrise::Config for Test {
   type CurrencyTidefi = Adapter<AccountId>;
   type Cooldown = Cooldown;
   type MaximumRewardPerSwap = MaximumRewardPerSwap;
+  type LeftoverSwapRebates = LeftoverSwapRebates;
 }
 
 impl pallet_tidefi_stake::Config for Test {

--- a/frame/tidefi/src/mock.rs
+++ b/frame/tidefi/src/mock.rs
@@ -33,7 +33,7 @@ use sp_core::H256;
 use sp_runtime::{
   testing::Header,
   traits::{BlakeTwo256, IdentityLookup},
-  DispatchError, DispatchResult, Permill,
+  DispatchError, DispatchResult, FixedU128, Permill,
 };
 use std::marker::PhantomData;
 use system::EnsureRoot;

--- a/frame/tidefi/src/mock.rs
+++ b/frame/tidefi/src/mock.rs
@@ -185,7 +185,8 @@ parameter_types! {
   pub const Cooldown: BlockNumber = 10;
   // max 10k rewards
   pub const MaximumRewardPerSwap: Balance = 10_000_000_000_000_000;
-
+  // 50%
+  pub const LeftoverSwapRebates: FixedU128 = FixedU128::from_inner(500_000_000_000_000_000);
 }
 
 impl pallet_tidefi::Config for Test {
@@ -275,6 +276,7 @@ impl pallet_sunrise::Config for Test {
   type CurrencyTidefi = Adapter<AccountId>;
   type Cooldown = Cooldown;
   type MaximumRewardPerSwap = MaximumRewardPerSwap;
+  type LeftoverSwapRebates = LeftoverSwapRebates;
 }
 
 impl pallet_tidefi_stake::Config for Test {

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -986,7 +986,7 @@ mod helpers {
           SunriseSwapPool {
             id: 1,
             minimum_tdfy_value: 0,
-            transactions_remaining: 1_000,
+            transactions_remaining: 100_000,
             balance: assets::Asset::Tdfy.saturating_mul(67_200_000),
             // 100%
             rebates: FixedU128::saturating_from_rational(100_u32, 100_u32),
@@ -995,7 +995,7 @@ mod helpers {
             id: 2,
             // 100 TDFY's minimum value
             minimum_tdfy_value: assets::Asset::Tdfy.saturating_mul(100),
-            transactions_remaining: 1_000,
+            transactions_remaining: 100_000,
             balance: assets::Asset::Tdfy.saturating_mul(57_600_000),
             // 125%
             rebates: FixedU128::saturating_from_rational(125_u32, 100_u32),
@@ -1004,7 +1004,7 @@ mod helpers {
             id: 3,
             // 10_000 TDFY's minimum value
             minimum_tdfy_value: assets::Asset::Tdfy.saturating_mul(10_000),
-            transactions_remaining: 100,
+            transactions_remaining: 50_000,
             balance: assets::Asset::Tdfy.saturating_mul(38_400_000),
             // 150%
             rebates: FixedU128::saturating_from_rational(150_u32, 100_u32),
@@ -1013,7 +1013,7 @@ mod helpers {
             id: 4,
             // 50_000 TDFY's minimum value
             minimum_tdfy_value: assets::Asset::Tdfy.saturating_mul(50_000),
-            transactions_remaining: 100,
+            transactions_remaining: 10_000,
             balance: assets::Asset::Tdfy.saturating_mul(19_200_000),
             // 200%
             rebates: FixedU128::saturating_from_rational(200_u32, 100_u32),
@@ -1022,7 +1022,7 @@ mod helpers {
             id: 5,
             // 100_000 TDFY's minimum value
             minimum_tdfy_value: assets::Asset::Tdfy.saturating_mul(100_000),
-            transactions_remaining: 100,
+            transactions_remaining: 1_000,
             balance: assets::Asset::Tdfy.saturating_mul(9_600_000),
             // 300%
             rebates: FixedU128::saturating_from_rational(300_u32, 100_u32),

--- a/runtime/common/config/tidefi.rs
+++ b/runtime/common/config/tidefi.rs
@@ -27,7 +27,7 @@ use frame_support::{
   traits::{ConstU128, EitherOfDiverse, EnsureOrigin},
 };
 use frame_system::{EnsureRoot, RawOrigin};
-use sp_runtime::{traits::AccountIdConversion, Permill};
+use sp_runtime::{traits::AccountIdConversion, FixedU128, Permill};
 
 parameter_types! {
   pub const ApprovalDeposit: Balance = TDFY;
@@ -80,6 +80,8 @@ parameter_types! {
   pub const Cooldown: BlockNumber = 10;
   // Maximum sunrise rewards before rewards allocation (in TDFY's)
   pub const MaximumRewardPerSwap: Balance = 100_000_000_000_000_000;
+  // Rebates applied to left-over pool
+  pub const LeftoverSwapRebates: FixedU128 = FixedU128::from_inner(500_000_000_000_000_000);
 }
 
 pub struct EnsureRootOrAssetRegistry;
@@ -237,4 +239,5 @@ impl pallet_sunrise::Config for Runtime {
   type CurrencyTidefi = Adapter<AccountId>;
   type Cooldown = Cooldown;
   type MaximumRewardPerSwap = MaximumRewardPerSwap;
+  type LeftoverSwapRebates = LeftoverSwapRebates;
 }


### PR DESCRIPTION
Implement new const `LeftoverSwapRebates` for sunrise pallet.

This is a `FixedU128` representing the rebates applied to the leftover pool.

When a pool reach the transactions limit, the remaining balance is moved into the leftover pool that's been assigned if no pool available for the current swap.