### PR TITLE
Migrate: `fees` and `tidefi-staking` to V2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,6 +4331,8 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal",
+ "log",
  "pallet-asset-registry",
  "pallet-assets",
  "pallet-balances",

--- a/frame/fees/Cargo.toml
+++ b/frame/fees/Cargo.toml
@@ -14,6 +14,7 @@ package = 'parity-scale-codec'
 version = '3'
 
 [dependencies]
+hex-literal = "0.3.1"
 scale-info = { version = "2.0", default-features = false }
 frame-support = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 frame-system = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
@@ -30,6 +31,7 @@ pallet-asset-registry = { path = "../asset-registry", default-features = false }
 pallet-tidefi-stake = { path = "../tidefi-stake", default-features = false }
 sp-arithmetic = {  default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 frame-benchmarking = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain", optional = true }
+log = { version = "0.4.17", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.119" }

--- a/frame/fees/src/lib.rs
+++ b/frame/fees/src/lib.rs
@@ -28,6 +28,8 @@ pub use weights::*;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
+pub mod migrations;
+
 // Re-export pallet items so that they can be accessed from the crate namespace.
 pub use pallet::*;
 
@@ -68,7 +70,7 @@ pub mod pallet {
   };
 
   /// The current storage version.
-  const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+  const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
   type BoundedAccountFees = BoundedVec<(CurrencyId, Fee), ConstU32<1_000>>;
 

--- a/frame/fees/src/migrations/mod.rs
+++ b/frame/fees/src/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod v2;

--- a/frame/fees/src/migrations/v2.rs
+++ b/frame/fees/src/migrations/v2.rs
@@ -67,6 +67,12 @@ where
         &staking_pool_account_id,
         false,
       );
+      log::info!(
+        target: "runtime::fees",
+        "Balance of the {} staking pool: {}",
+        asset_symbol,
+        staking_balance,
+      );
 
       // balance of the fees pallet
       let fees_balance = <T as pallet_fees::Config>::CurrencyTidefi::reducible_balance(
@@ -74,10 +80,22 @@ where
         &fees_account_id,
         false,
       );
+      log::info!(
+        target: "runtime::fees",
+        "Balance of the {} fees account: {}",
+        asset_symbol,
+        fees_balance,
+      );
 
       if let Some((principal, _)) = staking_pool_size.get(&currency_id) {
         if staking_balance < *principal {
           let missing_funds = principal.saturating_sub(staking_balance);
+          log::info!(
+            target: "runtime::fees",
+            "Missing {} {} in the staking pool",
+            missing_funds,
+            asset_symbol,
+          );
           if missing_funds > 0 && missing_funds <= fees_balance {
             let result = <T as pallet_fees::Config>::CurrencyTidefi::transfer(
               currency_id,
@@ -100,7 +118,7 @@ where
               "Staking pool for {} balance match {}={}",
               asset_symbol,
               staking_balance,
-              principal
+              principal,
             );
           }
 

--- a/frame/fees/src/migrations/v2.rs
+++ b/frame/fees/src/migrations/v2.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use hex_literal::hex;
 use sp_runtime::traits::AccountIdConversion;
-use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 use tidefi_primitives::{assets::Asset, Balance, CurrencyId};
 
 pub fn migrate<
@@ -52,9 +52,8 @@ where
       "Expected staking pool {:?}",
       staking_pool_size.iter().map(|(currency_id, b)| {
         let asset: Asset = currency_id.clone().try_into().expect("valid currency");
-        let asset_symbol = asset.symbol();
-        (asset_symbol, b)
-      }),
+        (asset.symbol(), *b)
+      }).collect::<Vec<_>>(),
     );
 
     // transfer assets to staking pool or to operator account

--- a/frame/fees/src/migrations/v2.rs
+++ b/frame/fees/src/migrations/v2.rs
@@ -1,0 +1,179 @@
+use crate as pallet_fees;
+use frame_support::{
+  traits::{
+    fungibles::{Inspect, Transfer},
+    Get, GetStorageVersion, PalletInfoAccess, StorageVersion,
+  },
+  weights::Weight,
+};
+use hex_literal::hex;
+use sp_runtime::traits::AccountIdConversion;
+use sp_std::collections::btree_map::BTreeMap;
+use tidefi_primitives::{Balance, CurrencyId};
+
+pub fn migrate<
+  T: pallet_fees::Config + pallet_tidefi_stake::Config + pallet_assets::Config,
+  P: GetStorageVersion + PalletInfoAccess,
+>() -> Weight
+where
+  <T as frame_system::Config>::AccountId: From<[u8; 32]>,
+{
+  let on_chain_storage_version = <P as GetStorageVersion>::on_chain_storage_version();
+  log::info!(
+    target: "runtime::fees",
+    "Running migration to v2 for fees with storage version {:?}",
+    on_chain_storage_version,
+  );
+  if on_chain_storage_version < 2 {
+    let mut staking_pool_size: BTreeMap<CurrencyId, (Balance, Balance)> = BTreeMap::new();
+
+    let staking_pool_account_id: T::AccountId =
+      <T as pallet_tidefi_stake::Config>::StakePalletId::get().into_account_truncating();
+    // we default our operator, if staking migration isnt completed for any reason, we could
+    // have the correct account id for our migration
+    let operator_account_id: T::AccountId = pallet_tidefi_stake::OperatorAccountId::<T>::get()
+      .unwrap_or(hex!["8e14d1ac896ea00e18d855588ee13103449cc6e41d4b0173d917cabea84bdb08"].into());
+    let fees_account_id: T::AccountId =
+      <T as pallet_fees::Config>::FeesPalletId::get().into_account_truncating();
+
+    pallet_tidefi_stake::AccountStakes::<T>::iter().for_each(|(_, stakes)| {
+      stakes.iter().for_each(|stake| {
+        if let Some((principal, initial)) = staking_pool_size.get_mut(&stake.currency_id) {
+          *principal = principal.saturating_add(stake.principal);
+          *initial = initial.saturating_add(stake.initial_balance);
+        } else {
+          staking_pool_size.insert(stake.currency_id, (stake.principal, stake.initial_balance));
+        }
+      });
+    });
+
+    log::info!(
+      target: "runtime::fees",
+      "Expected staking pool {:?}",
+      staking_pool_size,
+    );
+
+    // transfer assets to staking pool or to operator account
+    pallet_tidefi_stake::StakingCurrencyMeta::<T>::iter_keys().for_each(|currency_id| {
+      // balance of the staking pool
+      let staking_balance = <T as pallet_fees::Config>::CurrencyTidefi::reducible_balance(
+        currency_id,
+        &staking_pool_account_id,
+        false,
+      );
+
+      // balance of the fees pallet
+      let fees_balance = <T as pallet_fees::Config>::CurrencyTidefi::reducible_balance(
+        currency_id,
+        &fees_account_id,
+        false,
+      );
+
+      if let Some((principal, _)) = staking_pool_size.get(&currency_id) {
+        if staking_balance < *principal {
+          let missing_funds = principal.saturating_sub(staking_balance);
+          if missing_funds > 0 && missing_funds <= fees_balance {
+            let result = <T as pallet_fees::Config>::CurrencyTidefi::transfer(
+              currency_id,
+              &fees_account_id,
+              &staking_pool_account_id,
+              missing_funds,
+              false,
+            );
+
+            log::info!(
+              target: "runtime::fees",
+              "Transfered {} {:?} from fees to staking pallet; outcome: {:?}",
+              missing_funds,
+              currency_id,
+              result
+            );
+          } else {
+            log::info!(
+              target: "runtime::fees",
+              "Staking pool for {:?} balance match {}={}",
+              currency_id,
+              staking_balance,
+              principal
+            );
+          }
+
+          // if funds left, send to operator
+          let funds_left = fees_balance.saturating_sub(missing_funds);
+          if funds_left > 0 {
+            let result = <T as pallet_fees::Config>::CurrencyTidefi::transfer(
+              currency_id,
+              &fees_account_id,
+              &operator_account_id,
+              funds_left,
+              false,
+            );
+
+            log::info!(
+              target: "runtime::fees",
+              "Transfered {} {:?} from fees to operator account; outcome: {:?}",
+              funds_left,
+              currency_id,
+              result
+            );
+          } else {
+            log::info!(
+              target: "runtime::fees",
+              "No funds left for {:?} in the fees pallet for the operator",
+              currency_id
+            );
+          }
+        } else {
+          log::info!(
+            target: "runtime::fees",
+            "Staking pool for {:?} balance match {}={}",
+            currency_id,
+            staking_balance,
+            principal
+          );
+        }
+      };
+    });
+
+    // transfer TDFY funds of the fee pallet to the operator
+    let tdfy_fees_pallet_balance = <T as pallet_fees::Config>::CurrencyTidefi::reducible_balance(
+      CurrencyId::Tdfy,
+      &fees_account_id,
+      true,
+    );
+    if tdfy_fees_pallet_balance > 0 {
+      let result = <T as pallet_fees::Config>::CurrencyTidefi::transfer(
+        CurrencyId::Tdfy,
+        &fees_account_id,
+        &operator_account_id,
+        tdfy_fees_pallet_balance,
+        true,
+      );
+
+      log::info!(
+        target: "runtime::fees",
+        "Transfered {} {:?} from fees to operator account; outcome: {:?}",
+        tdfy_fees_pallet_balance,
+        CurrencyId::Tdfy,
+        result
+      );
+    }
+
+    StorageVersion::new(2).put::<P>();
+    <T as frame_system::Config>::BlockWeights::get().max_block
+  } else {
+    log::warn!(
+      target: "runtime::fees",
+      "Attempted to apply migration to v2 but failed because storage version is {:?}",
+      on_chain_storage_version,
+    );
+    0
+  }
+}
+
+pub fn post_migration<
+  T: pallet_fees::Config + pallet_tidefi_stake::Config,
+  P: GetStorageVersion + PalletInfoAccess,
+>() {
+  assert_eq!(<P as GetStorageVersion>::on_chain_storage_version(), 2);
+}

--- a/frame/fees/src/migrations/v2.rs
+++ b/frame/fees/src/migrations/v2.rs
@@ -160,6 +160,12 @@ where
     }
 
     StorageVersion::new(2).put::<P>();
+
+    log::info!(
+      target: "runtime::fees",
+      "Migrated fees balance successfully."
+    );
+
     <T as frame_system::Config>::BlockWeights::get().max_block
   } else {
     log::warn!(

--- a/frame/fees/src/mock.rs
+++ b/frame/fees/src/mock.rs
@@ -48,7 +48,6 @@ use tidefi_primitives::{
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u128;
-
 #[derive(
   Encode,
   Decode,
@@ -66,15 +65,21 @@ type Balance = u128;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash))]
 pub struct AccountId(pub u64);
 
-impl sp_std::fmt::Display for AccountId {
-  fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-    write!(f, "{}", self.0)
+impl From<[u8; 32]> for AccountId {
+  fn from(x: [u8; 32]) -> Self {
+    Self(x[0].saturating_mul(x[24]) as u64)
   }
 }
 
 impl From<u64> for AccountId {
   fn from(account_id: u64) -> Self {
     Self(account_id)
+  }
+}
+
+impl sp_std::fmt::Display for AccountId {
+  fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+    write!(f, "{}", self.0)
   }
 }
 

--- a/frame/tidefi-stake/src/migrations/v2.rs
+++ b/frame/tidefi-stake/src/migrations/v2.rs
@@ -2,7 +2,7 @@ use crate as pallet_tidefi_stake;
 use frame_support::{
   pallet_prelude::ValueQuery,
   storage_alias,
-  traits::{Get, GetStorageVersion, PalletInfoAccess},
+  traits::{Get, GetStorageVersion, PalletInfoAccess, StorageVersion},
   weights::Weight,
 };
 use hex_literal::hex;
@@ -34,10 +34,10 @@ where
     on_chain_storage_version,
   );
   if on_chain_storage_version < 2 {
-    // update `PendingStoredSessions`
     let stored_session_size = pallet_tidefi_stake::PendingStoredSessions::<T>::count();
     let mut unstake_queue_size: u32 = 0;
 
+    // update `PendingStoredSessions`
     pallet_tidefi_stake::PendingStoredSessions::<T>::translate(|_, _: ()| Some(Default::default()));
 
     // migrate unstake queue
@@ -47,18 +47,21 @@ where
         pallet_tidefi_stake::QueueUnstake::<T>::insert(hash, (account_id, expected_end));
         unstake_queue_size += 1;
       });
+    UnstakeQueue::<T>::kill();
 
     // add default operator
     pallet_tidefi_stake::OperatorAccountId::<T>::put::<T::AccountId>(
       hex!["8e14d1ac896ea00e18d855588ee13103449cc6e41d4b0173d917cabea84bdb08"].into(),
     );
 
+    let expected_stored_session_rw = stored_session_size.saturating_mul(2).into();
+    let expected_unstake_queue_rw = unstake_queue_size.saturating_mul(2).into();
     weight = weight
       .saturating_add(
-        T::DbWeight::get().reads_writes(stored_session_size.into(), stored_session_size.into()),
+        T::DbWeight::get().reads_writes(expected_stored_session_rw, expected_stored_session_rw),
       )
       .saturating_add(
-        T::DbWeight::get().reads_writes(unstake_queue_size.into(), unstake_queue_size.into()),
+        T::DbWeight::get().reads_writes(expected_unstake_queue_rw, expected_unstake_queue_rw),
       );
 
     log::info!(
@@ -67,6 +70,8 @@ where
       stored_session_size,
       unstake_queue_size
     );
+
+    StorageVersion::new(2).put::<P>();
   } else {
     log::warn!(
       target: "runtime::tidefi-stake",
@@ -76,4 +81,8 @@ where
   }
 
   weight
+}
+
+pub fn post_migration<T: pallet_tidefi_stake::Config, P: GetStorageVersion + PalletInfoAccess>() {
+  assert_eq!(<P as GetStorageVersion>::on_chain_storage_version(), 2);
 }

--- a/frame/tidefi-stake/src/migrations/v2.rs
+++ b/frame/tidefi-stake/src/migrations/v2.rs
@@ -84,7 +84,7 @@ where
 
       log::info!(
         target: "runtime::tidefi-stake",
-        "Update {} staking pool from {} to {} (including rewards)",
+        "Updated {} staking pool from {} to {} (including rewards)",
         asset.symbol(),
         balance,
         new_balance

--- a/frame/tidefi-stake/src/tests.rs
+++ b/frame/tidefi-stake/src/tests.rs
@@ -1710,3 +1710,11 @@ pub fn should_calculate_rewards() {
     assert_eq!(SessionTotalFees::<Test>::iter().count(), 0);
   });
 }
+
+#[test]
+fn test_migration_v2() {
+  new_test_ext().execute_with(|| {
+    crate::migrations::v2::migrate::<Test, TidefiStaking>();
+    crate::migrations::v2::post_migration::<Test, TidefiStaking>();
+  });
+}

--- a/frame/utils/src/lib.rs
+++ b/frame/utils/src/lib.rs
@@ -68,6 +68,13 @@ macro_rules! construct_mock_runtime {
           Self(account_id as u64)
         }
       }
+      // random adresss bytes (0 * 1) + 31
+      impl From<[u8; 32]> for AccountId {
+         fn from(account_id: [u8; 32]) -> Self {
+           Self(account_id[0].saturating_mul(account_id[1]).saturating_add(account_id[31]) as u64)
+         }
+       }
+
       // Configure a mock runtime to test the pallet.
       frame_support::construct_runtime!(
         pub enum Test where

--- a/runtime/lagoon/src/lib.rs
+++ b/runtime/lagoon/src/lib.rs
@@ -251,7 +251,7 @@ pub type Executive = frame_executive::Executive<
   frame_system::ChainContext<Runtime>,
   Runtime,
   AllPalletsWithSystem,
-  (MigrateTidefiStakingToV2, TransferFeesBalanceToStaking),
+  (MigrateTidefiStakingToV2, MigrateFeesToV2),
 >;
 
 pub struct MigrateTidefiStakingToV2;
@@ -268,8 +268,8 @@ impl frame_support::traits::OnRuntimeUpgrade for MigrateTidefiStakingToV2 {
   }
 }
 
-pub struct TransferFeesBalanceToStaking;
-impl frame_support::traits::OnRuntimeUpgrade for TransferFeesBalanceToStaking {
+pub struct MigrateFeesToV2;
+impl frame_support::traits::OnRuntimeUpgrade for MigrateFeesToV2 {
   fn on_runtime_upgrade() -> frame_support::weights::Weight {
     pallet_fees::migrations::v2::migrate::<Runtime, Fees>()
   }

--- a/runtime/lagoon/src/lib.rs
+++ b/runtime/lagoon/src/lib.rs
@@ -251,33 +251,30 @@ pub type Executive = frame_executive::Executive<
   frame_system::ChainContext<Runtime>,
   Runtime,
   AllPalletsWithSystem,
-  (MigrateTidefiStakingToV2,),
+  (MigrateTidefiStakingToV2, TransferFeesBalanceToStaking),
 >;
 
 pub struct MigrateTidefiStakingToV2;
 impl frame_support::traits::OnRuntimeUpgrade for MigrateTidefiStakingToV2 {
-  #[cfg(feature = "try-runtime")]
-  fn pre_upgrade() -> Result<(), &'static str> {
-    Ok(())
-  }
   fn on_runtime_upgrade() -> frame_support::weights::Weight {
-    pallet_tidefi_stake::migrations::v2::migrate::<Runtime, Fees>()
+    pallet_tidefi_stake::migrations::v2::migrate::<Runtime, TidefiStaking>()
+  }
+  #[cfg(feature = "try-runtime")]
+  fn post_upgrade() -> Result<(), &'static str> {
+    Ok(pallet_tidefi_stake::migrations::v2::post_migration::<
+      Runtime,
+      TidefiStaking,
+    >())
   }
 }
 
-/*
-/// A migration which renames the pallet `BagsList` to `VoterList`
-pub struct RenameBagsListToVoterList;
-impl frame_support::traits::OnRuntimeUpgrade for RenameBagsListToVoterList {
-  #[cfg(feature = "try-runtime")]
-  fn pre_upgrade() -> Result<(), &'static str> {
-    // For other pre-upgrade checks, we need the storage to already be migrated.
-    frame_support::storage::migration::move_pallet(b"BagsList", b"VoterList");
-    Ok(())
-  }
+pub struct TransferFeesBalanceToStaking;
+impl frame_support::traits::OnRuntimeUpgrade for TransferFeesBalanceToStaking {
   fn on_runtime_upgrade() -> frame_support::weights::Weight {
-    frame_support::storage::migration::move_pallet(b"BagsList", b"VoterList");
-    frame_support::weights::Weight::MAX
+    pallet_fees::migrations::v2::migrate::<Runtime, Fees>()
+  }
+  #[cfg(feature = "try-runtime")]
+  fn post_upgrade() -> Result<(), &'static str> {
+    Ok(pallet_fees::migrations::v2::post_migration::<Runtime, Fees>())
   }
 }
-*/

--- a/runtime/tidechain/src/lib.rs
+++ b/runtime/tidechain/src/lib.rs
@@ -257,12 +257,15 @@ pub type Executive = frame_executive::Executive<
 
 pub struct MigrateTidefiStakingToV2;
 impl frame_support::traits::OnRuntimeUpgrade for MigrateTidefiStakingToV2 {
-  #[cfg(feature = "try-runtime")]
-  fn pre_upgrade() -> Result<(), &'static str> {
-    Ok(())
-  }
   fn on_runtime_upgrade() -> frame_support::weights::Weight {
-    pallet_tidefi_stake::migrations::v2::migrate::<Runtime, Fees>()
+    pallet_tidefi_stake::migrations::v2::migrate::<Runtime, TidefiStaking>()
+  }
+  #[cfg(feature = "try-runtime")]
+  fn post_upgrade() -> Result<(), &'static str> {
+    Ok(pallet_tidefi_stake::migrations::v2::post_migration::<
+      Runtime,
+      TidefiStaking,
+    >())
   }
 }
 

--- a/runtime/tidechain/src/lib.rs
+++ b/runtime/tidechain/src/lib.rs
@@ -44,22 +44,6 @@ use sp_version::RuntimeVersion;
 
 #[cfg(feature = "std")]
 pub use crate::api::{api::dispatch, RuntimeApi};
-// Copyright 2021-2022 Semantic Network Ltd.
-// This file is part of Tidechain.
-
-// Tidechain is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// Tidechain is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Tidechain.  If not, see <http://www.gnu.org/licenses/>.
-
 pub use crate::types::{
   AccountId, AccountIndex, Address, AssetId, Balance, Block, BlockId, BlockNumber,
   CheckedExtrinsic, Hash, Header, Moment, Nonce, Signature, SignedBlock, SignedExtra,
@@ -268,7 +252,7 @@ pub type Executive = frame_executive::Executive<
   frame_system::ChainContext<Runtime>,
   Runtime,
   AllPalletsWithSystem,
-  (MigrateTidefiStakingToV2,),
+  (MigrateTidefiStakingToV2, TransferFeesBalanceToStaking),
 >;
 
 pub struct MigrateTidefiStakingToV2;
@@ -279,5 +263,16 @@ impl frame_support::traits::OnRuntimeUpgrade for MigrateTidefiStakingToV2 {
   }
   fn on_runtime_upgrade() -> frame_support::weights::Weight {
     pallet_tidefi_stake::migrations::v2::migrate::<Runtime, Fees>()
+  }
+}
+
+pub struct TransferFeesBalanceToStaking;
+impl frame_support::traits::OnRuntimeUpgrade for TransferFeesBalanceToStaking {
+  fn on_runtime_upgrade() -> frame_support::weights::Weight {
+    pallet_fees::migrations::v2::migrate::<Runtime, Fees>()
+  }
+  #[cfg(feature = "try-runtime")]
+  fn post_upgrade() -> Result<(), &'static str> {
+    Ok(pallet_fees::migrations::v2::post_migration::<Runtime, Fees>())
   }
 }

--- a/runtime/tidechain/src/lib.rs
+++ b/runtime/tidechain/src/lib.rs
@@ -252,7 +252,7 @@ pub type Executive = frame_executive::Executive<
   frame_system::ChainContext<Runtime>,
   Runtime,
   AllPalletsWithSystem,
-  (MigrateTidefiStakingToV2, TransferFeesBalanceToStaking),
+  (MigrateTidefiStakingToV2, MigrateFeesToV2),
 >;
 
 pub struct MigrateTidefiStakingToV2;
@@ -269,8 +269,8 @@ impl frame_support::traits::OnRuntimeUpgrade for MigrateTidefiStakingToV2 {
   }
 }
 
-pub struct TransferFeesBalanceToStaking;
-impl frame_support::traits::OnRuntimeUpgrade for TransferFeesBalanceToStaking {
+pub struct MigrateFeesToV2;
+impl frame_support::traits::OnRuntimeUpgrade for MigrateFeesToV2 {
   fn on_runtime_upgrade() -> frame_support::weights::Weight {
     pallet_fees::migrations::v2::migrate::<Runtime, Fees>()
   }


### PR DESCRIPTION
We are running 2 migrations (MigrateTidefiStakingToV2, MigrateFeesToV2)

Each of them can run fully independently, that mean, if any of them run first, it shouldn't affect anything.

### MigrateTidefiStakingToV2

- Insert default operator
- Update the store encoding for `PendingStoredSessions` 
- All pending `UnstakeQueue` are migrated ot the new `QueueUnstake` then drained
- Staking pool is recomputed with the principa of each stake to make sure they are matching

### MigrateFeesToV2

- Rebalance the `staking` pool balance by transferring the missing balance from the `fees` pallet
- All remaining funds are transferred to the operator account
