### PR TITLE
Handled transfer errors during confirm swaps

### DIFF
--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -35,10 +35,11 @@ pub use pallet::*;
 pub mod pallet {
   use super::*;
   use frame_support::{
+    dispatch::{DispatchError, DispatchResult},
     inherent::Vec,
     pallet_prelude::*,
     traits::fungibles::{Inspect, InspectHold, Mutate, MutateHold, Transfer},
-    transactional, PalletId,
+    PalletId,
   };
   use frame_system::pallet_prelude::*;
   #[cfg(feature = "std")]
@@ -201,85 +202,71 @@ pub mod pallet {
     /// Invalid request ID.
     InvalidRequestId,
     /// Invalid swap request status.
-    InvalidSwapRequestStatus,
-    /// Invalid market maker swap request status.
-    InvalidMarketMakerSwapRequestStatus,
-    /// Market maker buy token does not match swap sell token
-    MarketMakerBuyTokenNotMatchSwapSellToken,
-    /// The sum of market maker sell amount and fee causes overflow.
-    MarketMakerPayoutOverflow,
-    /// Market maker sells more than market maker swap from amount
-    MarketMakerCannotOversell,
-    /// Market maker has not enough token swap and pay swap fees
-    MarketMakerHasNotEnoughTokenToSellAndPaySwapFees,
+    InvalidRequestSwapStatus,
+    /// Request swap asset types must be different
+    SwapAssetTypesShouldBeDifferent,
     /// Invalid market maker request ID, includes an index in the SwapConfirmation list
     InvalidMarketMakerRequestId { index: u8 },
-    /// There is a conflict in the request.
-    Conflict,
-    /// Unable to transfer token.
-    TransferFailed,
-    /// Unable to mint token.
-    MintFailed,
-    /// Unable to release funds.
-    ReleaseFailed,
-    /// Unable to register trade swap network fees.
-    TraderSwapFeeRegistrationFailed,
-    /// Failed to update trader swap
-    UpdateTraderSwapFailed,
-    /// Unable to register market maker swap network fees.
-    MarketMakerSwapFeeRegistrationFailed,
-    /// Failed to update market maker swap
-    UpdateMarketMakerSwapFailed,
+    /// Invalid market maker swap request status.
+    InvalidMarketMakerSwapRequestStatus,
+    /// Market maker buy asset type does not match with sell asset type
+    TwoRequestsAssetTypesNotMatch,
     /// Unknown Asset.
     UnknownAsset,
-    /// Processing one of the swaps failed
-    ProcessMarketMakerSwapFailed,
-    /// Transfer reserved trader selling tokens to market maker failed
-    TransferFromTraderToMarketMakerFailed,
-    /// Transfer reserved trader swap fee to market maker failed
-    TransferTraderSwapFeeFailed,
-    /// Transfer reserved market maker selling tokens to trader failed
-    TransferFromMarketMakerToTraderFailed,
-    /// Transfer reserved market maker swap fee to trader failed
-    TransferMarketMakerSwapFeeFailed,
-    /// The sum of market makers selling amount and fees causes overflow.
-    TraderPayoutOverflow,
-    /// No Funds available for this Asset Id to swap and pay swap fees
-    TraderHasNotEnoughTokenToSellAndPaySwapFees,
+    /// Unable to calculate slippage
+    SlippageOverflow,
+    /// Arithmetic error
+    ArithmeticError,
     /// Request contains offer that is less than swap lower bound
     OfferIsLessThanSwapLowerBound { index: u8 },
     /// Request contains offer that is greater than swap upper bound
     OfferIsGreaterThanSwapUpperBound { index: u8 },
-    /// Trader sells more than trader swap from amount
-    TraderCannotOversell,
     /// Request contains offer that is less than market maker swap lower bound
     OfferIsLessThanMarketMakerSwapLowerBound { index: u8 },
     /// Request contains offer that is greater than market maker swap upper bound
     OfferIsGreaterThanMarketMakerSwapUpperBound { index: u8 },
-    /// Market Makers do not have enough funds left to sell
-    MarketMakerHasNotEnoughTokenLeftToSell,
-    /// Trader cannot deposit received funds of the trade
-    TraderCantDeposit,
-    /// Fees account cannot deposit swap fees paid by trader
-    CantDepositTraderSwapFees,
-    /// Fees account cannot deposit swap fees paid by market maker
-    CantDepositMarketMakerSwapFees,
+    /// Market Maker swap do not have enough funds left to sell
+    MarketMakerSwapHasNotEnoughTokenLeftToSell,
+    /// Trader swap do not have enough funds left to sell
+    TraderSwapHasNotEnoughTokenLeftToSell,
+    /// Trader sells more than trader swap from amount
+    RequestCannotOversell,
+    /// The sum of market maker sell amount and fee causes overflow.
+    PayoutOverflow,
+    /// Market maker has not enough token swap and pay swap fees
+    SellerDoesNotHoldEnoughFundToSellAndPaySwapFees,
     /// Market Makers cannot deposit source funds of the trade
-    MarketMakerCantDeposit,
+    BuyerCannotDeposit,
+    /// Fees account cannot deposit swap fees paid by market maker
+    CannotDepositSwapFee,
+    /// Failed to update market maker swap
+    UpdateMarketMakerSwapFailed,
     /// Delete trader's swap request from Swaps failed
     DeleteSwapFailed,
+    /// Unable to release funds.
+    ReleaseFailed,
     /// Release trader's unswapped funds failed
     ReleaseUnswappedFundsFailed,
     /// Update trader's swap request status in AccountSwaps failed
     UpdateAccountSwapRequestStatusFailed,
+    /// Failed to update trader swap
+    UpdateTraderSwapFailed,
+    /// Transfer reserved trader selling tokens to market maker failed
+    TransferTraderSwapAssetsToMarketMakerFailed,
+    /// Transfer reserved trader swap fee to market maker failed
+    TransferTraderSwapFeeFailed,
+    /// Unable to register trade swap network fees.
+    TraderSwapFeeRegistrationFailed,
+    /// Transfer reserved market maker selling tokens to trader failed
+    TransferMarketMakerSwapAssetsToTraderFailed,
+    /// Transfer reserved market maker swap fee to trader failed
+    TransferMarketMakerSwapFeeFailed,
+    /// Unable to register market maker swap network fees.
+    MarketMakerSwapFeeRegistrationFailed,
     /// Swaps cap reached for this account id
     SwapOverflow,
-    /// Unable to calculate slippage
-    SlippageOverflow,
     /// Unknown Error.
     UnknownError,
-    /// Arithmetic error
-    ArithmeticError,
   }
 
   #[pallet::call]
@@ -306,260 +293,83 @@ pub mod pallet {
       let sender = ensure_signed(origin)?;
       ensure!(Some(sender) == Self::account_id(), Error::<T>::AccessDenied);
 
+      // Make sure this trade exsits in Swaps
+      let trade = Self::swaps(request_id).ok_or(Error::<T>::InvalidRequestId)?;
+
+      // Make sure the trade status is either pending or partially filled
+      ensure!(
+        trade.status == SwapStatus::Pending || trade.status == SwapStatus::PartiallyFilled,
+        Error::<T>::InvalidRequestSwapStatus
+      );
+
+      // Make sure buy asset type is different from sell asset type
+      ensure!(
+        trade.token_to != trade.token_from,
+        Error::<T>::SwapAssetTypesShouldBeDifferent
+      );
+
+      let mut trade_total_from: Balance = 0;
+      let mut trade_total_to: Balance = 0;
+      let mut trade_latest_from_filled: Balance = trade.amount_from_filled;
+      let mut trade_latest_to_filled: Balance = trade.amount_to_filled;
+
+      for (index, mm) in market_makers.iter().enumerate() {
+        // Make sure request exsits in Swaps
+        let market_maker_trade = Self::swaps(mm.request_id)
+          .ok_or(Error::<T>::InvalidMarketMakerRequestId { index: index as u8 })?;
+
+        let (trade_fee, market_maker_fee) = Self::validate_pair_of_swap_requests(
+          index,
+          &mm,
+          &market_maker_trade,
+          &trade,
+          trade_latest_from_filled,
+        )?;
+
+        Self::do_swaps(
+          &mm,
+          &trade,
+          trade_fee,
+          &market_maker_trade,
+          market_maker_fee,
+        )?;
+
+        trade_total_from += mm.amount_to_receive;
+        trade_total_to += mm.amount_to_send;
+        trade_latest_from_filled += mm.amount_to_receive;
+        trade_latest_to_filled += mm.amount_to_send;
+      }
+
       // Make sure the `request_id` exist
       Swaps::<T>::try_mutate_exists(request_id, |trade_request| {
-        let mut total_from: Balance = 0;
-        let mut total_to: Balance = 0;
-        let mut total_from_fees: Balance = 0;
-        let mut total_to_fees: Balance = 0;
+        if let Some(trade) = trade_request {
+          trade.amount_from_filled = trade_latest_from_filled;
+          trade.amount_to_filled = trade_latest_to_filled;
 
-        match trade_request {
-          None => {
-            return Err(Error::<T>::InvalidRequestId);
+          Self::update_swap_and_requestor_account(trade, request_id)
+            .map_err(|_| Error::<T>::UpdateTraderSwapFailed)?;
+
+          // Emit trade event on chain
+          Self::deposit_event(Event::<T>::SwapProcessed {
+            request_id,
+            initial_extrinsic_hash: trade.extrinsic_hash,
+            status: trade.status.clone(),
+            account_id: trade.account_id.clone(),
+            currency_from: trade.token_from,
+            currency_amount_from: trade_total_from,
+            currency_to: trade.token_to,
+            currency_amount_to: trade_total_to,
+          });
+
+          // Delete swap if it is completed or its type is Market
+          if trade.status == SwapStatus::Completed || trade.swap_type == SwapType::Market {
+            *trade_request = None;
           }
-          Some(trade) => {
-            // Make sure the trade status is pending or partially filled
-            if trade.status != SwapStatus::Pending && trade.status != SwapStatus::PartiallyFilled {
-              return Err(Error::<T>::InvalidSwapRequestStatus);
-            }
 
-            for (index, mm) in market_makers.iter().enumerate() {
-              let mm_trade_request = Swaps::<T>::try_get(mm.request_id)
-                .map_err(|_| Error::<T>::InvalidMarketMakerRequestId { index: index as u8 })?;
-
-              trade
-                .validate_slippage(&mm_trade_request, mm.amount_to_receive, mm.amount_to_send)
-                .map_err(|err| match err {
-                  SlippageError::UnknownAsset => Error::<T>::UnknownAsset,
-                  SlippageError::SlippageOverflow => Error::<T>::SlippageOverflow,
-                  SlippageError::ArithmeticError => Error::<T>::ArithmeticError,
-                  SlippageError::OfferIsLessThanSwapLowerBound => {
-                    Error::<T>::OfferIsLessThanSwapLowerBound { index: index as u8 }
-                  }
-                  SlippageError::OfferIsGreaterThanSwapUpperBound => {
-                    Error::<T>::OfferIsGreaterThanSwapUpperBound { index: index as u8 }
-                  }
-                  SlippageError::OfferIsLessThanMarketMakerSwapLowerBound => {
-                    Error::<T>::OfferIsLessThanMarketMakerSwapLowerBound { index: index as u8 }
-                  }
-                  SlippageError::OfferIsGreaterThanMarketMakerSwapUpperBound => {
-                    Error::<T>::OfferIsGreaterThanMarketMakerSwapUpperBound { index: index as u8 }
-                  }
-                })?;
-
-              let mm_trade_amount_and_fee = T::Fees::calculate_swap_fees(
-                trade.token_to,
-                mm.amount_to_send,
-                mm_trade_request.swap_type.clone(),
-                mm_trade_request.is_market_maker,
-              );
-
-              let market_maker_payout = mm
-                .amount_to_send
-                .checked_add(mm_trade_amount_and_fee.fee)
-                .ok_or(Error::<T>::MarketMakerPayoutOverflow)?;
-
-              // Make sure market marker have enough funds before we can continue
-              T::CurrencyTidefi::balance_on_hold(trade.token_to, &mm_trade_request.account_id)
-                .checked_sub(market_maker_payout)
-                .ok_or(Error::<T>::MarketMakerHasNotEnoughTokenToSellAndPaySwapFees)?;
-
-              // Make sure market maker can deposit the funds
-              T::CurrencyTidefi::can_deposit(
-                trade.token_from,
-                &mm_trade_request.account_id,
-                mm.amount_to_receive,
-                false,
-              )
-              .into_result()
-              .map_err(|_| Error::<T>::MarketMakerCantDeposit)?;
-
-              // Update total swap amounts and fees
-              total_from += mm.amount_to_receive;
-              total_to += mm.amount_to_send;
-
-              let trade_amount_and_fee = T::Fees::calculate_swap_fees(
-                trade.token_from,
-                mm.amount_to_receive,
-                trade.swap_type.clone(),
-                trade.is_market_maker,
-              );
-              total_from_fees += trade_amount_and_fee.fee;
-              total_to_fees += mm_trade_amount_and_fee.fee;
-            }
-
-            // Filled sold amount should be no more than the total amount to swap
-            ensure!(
-              trade.amount_from_filled + total_from <= trade.amount_from,
-              Error::TraderCannotOversell
-            );
-
-            // Make sure trader can withdraw the funds
-            let trader_payout = total_from
-              .checked_add(total_from_fees)
-              .ok_or(Error::<T>::TraderPayoutOverflow)?;
-
-            T::CurrencyTidefi::balance_on_hold(trade.token_from, &trade.account_id)
-              .checked_sub(trader_payout)
-              .ok_or(Error::<T>::TraderHasNotEnoughTokenToSellAndPaySwapFees)?;
-
-            // Make sure trader can deposit the funds
-            T::CurrencyTidefi::can_deposit(trade.token_to, &trade.account_id, total_to, false)
-              .into_result()
-              .map_err(|_| Error::<T>::TraderCantDeposit)?;
-
-            // Make sure fees account can deposit the trader swap fees
-            T::CurrencyTidefi::can_deposit(
-              trade.token_from,
-              &T::Fees::account_id(),
-              total_from_fees,
-              false,
-            )
-            .into_result()
-            .map_err(|_| Error::<T>::CantDepositTraderSwapFees)?;
-
-            // Make sure fees account can deposit all market maker swaps fees
-            T::CurrencyTidefi::can_deposit(
-              trade.token_to,
-              &T::Fees::account_id(),
-              total_to_fees,
-              false,
-            )
-            .into_result()
-            .map_err(|_| Error::<T>::CantDepositMarketMakerSwapFees)?;
-
-            for mm in market_makers.iter() {
-              Swaps::<T>::try_mutate_exists(mm.request_id, |mm_trade_request| {
-                if let Some(market_maker_trade_intent) = mm_trade_request {
-                  // a) Make sure the marketmaker trade request is still valid
-                  if market_maker_trade_intent.status != SwapStatus::Pending
-                    && market_maker_trade_intent.status != SwapStatus::PartiallyFilled
-                  {
-                    return Err(Error::<T>::InvalidMarketMakerSwapRequestStatus);
-                  }
-
-                  // b) Make sure the currency match
-                  if market_maker_trade_intent.token_from != trade.token_to {
-                    return Err(Error::<T>::MarketMakerBuyTokenNotMatchSwapSellToken);
-                  }
-
-                  // c) make sure market maker have enough funds in the trade intent request
-                  let available_funds = market_maker_trade_intent
-                    .amount_from
-                    .checked_sub(market_maker_trade_intent.amount_from_filled)
-                    .ok_or(Error::<T>::MarketMakerHasNotEnoughTokenLeftToSell)?;
-
-                  // d) prevent MM overflow
-                  if market_maker_trade_intent
-                    .amount_from_filled
-                    .checked_add(mm.amount_to_send)
-                    .ok_or(Error::<T>::ArithmeticError)?
-                    > market_maker_trade_intent.amount_from
-                  {
-                    return Err(Error::<T>::MarketMakerCannotOversell);
-                  }
-
-                  // e) make sure there is enough funds available
-                  if available_funds
-                    .checked_add(market_maker_trade_intent.slippage * available_funds)
-                    .ok_or(Error::<T>::ArithmeticError)?
-                    < mm.amount_to_send
-                  {
-                    return Err(Error::<T>::MarketMakerHasNotEnoughTokenLeftToSell);
-                  }
-
-                  market_maker_trade_intent.amount_from_filled = market_maker_trade_intent
-                    .amount_from_filled
-                    .checked_add(mm.amount_to_send)
-                    .ok_or(Error::<T>::ArithmeticError)?;
-
-                  market_maker_trade_intent.amount_to_filled = market_maker_trade_intent
-                    .amount_to_filled
-                    .checked_add(mm.amount_to_receive)
-                    .ok_or(Error::<T>::ArithmeticError)?;
-
-                  let trader_amount_and_fee = T::Fees::calculate_swap_fees(
-                    trade.token_from,
-                    mm.amount_to_receive,
-                    trade.swap_type.clone(),
-                    trade.is_market_maker,
-                  );
-
-                  let mm_amount_and_fee = T::Fees::calculate_swap_fees(
-                    trade.token_to,
-                    mm.amount_to_send,
-                    market_maker_trade_intent.swap_type.clone(),
-                    market_maker_trade_intent.is_market_maker,
-                  );
-
-                  // transfers swap funds and release funds if swap is completed or its type is Market
-                  if Self::process_swap(
-                    trade,
-                    mm,
-                    market_maker_trade_intent,
-                    &trader_amount_and_fee,
-                    &mm_amount_and_fee,
-                  )
-                  .is_err()
-                  {
-                    total_from -= mm.amount_to_receive;
-                    total_to -= mm.amount_to_send;
-                    total_from_fees -= trader_amount_and_fee.fee;
-                    total_to_fees -= mm_amount_and_fee.fee;
-                    return Err(Error::<T>::ProcessMarketMakerSwapFailed);
-                  }
-
-                  // Emit market maker trade event on chain
-                  Self::deposit_event(Event::<T>::SwapProcessed {
-                    request_id: mm.request_id,
-                    initial_extrinsic_hash: market_maker_trade_intent.extrinsic_hash,
-                    status: market_maker_trade_intent.status.clone(),
-                    account_id: market_maker_trade_intent.account_id.clone(),
-                    currency_from: market_maker_trade_intent.token_from,
-                    currency_amount_from: mm.amount_to_send,
-                    currency_to: market_maker_trade_intent.token_to,
-                    currency_amount_to: mm.amount_to_receive,
-                  });
-
-                  // Delete market maker swap if it is completed or its type is Market
-                  if market_maker_trade_intent.status == SwapStatus::Completed
-                    || market_maker_trade_intent.swap_type == SwapType::Market
-                  {
-                    *mm_trade_request = None;
-                  }
-                }
-
-                Ok(())
-              })?;
-            }
-
-            // Update both trade's buy and sell filled amounts
-            trade.amount_from_filled += total_from;
-            trade.amount_to_filled += total_to;
-
-            Self::update_swap_and_requestor_account(trade, request_id)
-              .map_err(|_| Error::<T>::UpdateTraderSwapFailed)?;
-
-            // Emit event on chain
-            Self::deposit_event(Event::<T>::SwapProcessed {
-              request_id,
-              initial_extrinsic_hash: trade.extrinsic_hash,
-              status: trade.status.clone(),
-              account_id: trade.account_id.clone(),
-              currency_from: trade.token_from,
-              currency_amount_from: total_from,
-              currency_to: trade.token_to,
-              currency_amount_to: total_to,
-            });
-
-            // Delete trader swap if it is completed or its type is Market
-            if trade.status == SwapStatus::Completed || trade.swap_type == SwapType::Market {
-              *trade_request = None;
-            }
-          }
+          Ok(())
+        } else {
+          Err(Error::<T>::InvalidRequestId)
         }
-
-        Ok(())
       })?;
 
       // Update last seen
@@ -771,31 +581,221 @@ pub mod pallet {
 
   // helper functions (not dispatchable)
   impl<T: Config> Pallet<T> {
-    #[transactional]
-    fn process_swap(
-      trade: &Swap<T::AccountId, T::BlockNumber>,
+    fn validate_pair_of_swap_requests(
+      index: usize,
       mm: &SwapConfirmation,
-      market_maker_trade_intent: &mut Swap<T::AccountId, T::BlockNumber>,
-      trader_amount_and_fee: &Fee,
-      mm_amount_and_fee: &Fee,
-    ) -> Result<(), DispatchError> {
+      market_maker_trade: &Swap<T::AccountId, T::BlockNumber>,
+      trade: &Swap<T::AccountId, T::BlockNumber>,
+      trade_latest_from_filled: Balance,
+    ) -> Result<(Balance, Balance), DispatchError> {
+      //  Make sure request is either pending or partially filled
+      ensure!(
+        market_maker_trade.status == SwapStatus::Pending
+          || market_maker_trade.status == SwapStatus::PartiallyFilled,
+        Error::<T>::InvalidMarketMakerSwapRequestStatus
+      );
+
+      // Make sure swap buyer and seller currencies match
+      ensure!(
+        market_maker_trade.token_to == trade.token_from
+          && market_maker_trade.token_from == trade.token_to,
+        Error::<T>::TwoRequestsAssetTypesNotMatch
+      );
+
+      // Make sure swap prices are within slippage tolerances
+      trade
+        .validate_slippage(&market_maker_trade, mm.amount_to_receive, mm.amount_to_send)
+        .map_err(|err| match err {
+          SlippageError::UnknownAsset => Error::<T>::UnknownAsset,
+          SlippageError::SlippageOverflow => Error::<T>::SlippageOverflow,
+          SlippageError::ArithmeticError => Error::<T>::ArithmeticError,
+          SlippageError::OfferIsLessThanSwapLowerBound => {
+            Error::<T>::OfferIsLessThanSwapLowerBound { index: index as u8 }
+          }
+          SlippageError::OfferIsGreaterThanSwapUpperBound => {
+            Error::<T>::OfferIsGreaterThanSwapUpperBound { index: index as u8 }
+          }
+          SlippageError::OfferIsLessThanMarketMakerSwapLowerBound => {
+            Error::<T>::OfferIsLessThanMarketMakerSwapLowerBound { index: index as u8 }
+          }
+          SlippageError::OfferIsGreaterThanMarketMakerSwapUpperBound => {
+            Error::<T>::OfferIsGreaterThanMarketMakerSwapUpperBound { index: index as u8 }
+          }
+        })?;
+
+      let trader_fee = Self::validate_fund_transfers(
+        &trade,
+        mm.amount_to_receive,
+        mm.amount_to_send,
+        trade_latest_from_filled,
+        false,
+      )?;
+
+      let market_maker_fee = Self::validate_fund_transfers(
+        &market_maker_trade,
+        mm.amount_to_send,
+        mm.amount_to_receive,
+        market_maker_trade.amount_from_filled,
+        true,
+      )?;
+
+      Ok((trader_fee.fee, market_maker_fee.fee))
+    }
+
+    fn validate_fund_transfers(
+      trade: &Swap<T::AccountId, T::BlockNumber>,
+      amount_to_sell: Balance,
+      amount_to_buy: Balance,
+      amount_already_sold: Balance,
+      is_market_maker: bool,
+    ) -> Result<Fee, Error<T>> {
+      let available_funds = if is_market_maker {
+        trade
+          .amount_from
+          .checked_sub(trade.amount_from_filled)
+          .ok_or(Error::<T>::MarketMakerSwapHasNotEnoughTokenLeftToSell)?
+      } else {
+        trade
+          .amount_from
+          .checked_sub(amount_already_sold)
+          .ok_or(Error::<T>::TraderSwapHasNotEnoughTokenLeftToSell)?
+      };
+
+      // Make sure accounts have enough funds in the trade request
+      ensure!(
+        available_funds >= amount_to_sell,
+        Error::RequestCannotOversell
+      );
+
+      // Make sure there is enough funds available
+      if is_market_maker
+        && available_funds
+          .checked_add(trade.slippage * available_funds)
+          .ok_or(Error::<T>::ArithmeticError)?
+          < amount_to_sell
+      {
+        return Err(Error::<T>::MarketMakerSwapHasNotEnoughTokenLeftToSell);
+      }
+
+      let amount_and_fee = T::Fees::calculate_swap_fees(
+        trade.token_from,
+        amount_to_sell,
+        trade.swap_type.clone(),
+        trade.is_market_maker,
+      );
+
+      let payout = amount_to_sell
+        .checked_add(amount_and_fee.fee)
+        .ok_or(Error::<T>::PayoutOverflow)?;
+
+      // Make sure seller has enough funds before we can continue
+      T::CurrencyTidefi::balance_on_hold(trade.token_from, &trade.account_id)
+        .checked_sub(payout)
+        .ok_or(Error::<T>::SellerDoesNotHoldEnoughFundToSellAndPaySwapFees)?;
+
+      // Make sure buyer can deposit the funds
+      T::CurrencyTidefi::can_deposit(trade.token_to, &trade.account_id, amount_to_buy, false)
+        .into_result()
+        .map_err(|_| Error::<T>::BuyerCannotDeposit)?;
+
+      // Make sure fees account can deposit trade fees
+      T::CurrencyTidefi::can_deposit(
+        trade.token_from,
+        &T::Fees::account_id(),
+        amount_and_fee.fee,
+        false,
+      )
+      .into_result()
+      .map_err(|_| Error::<T>::CannotDepositSwapFee)?;
+
+      Ok(amount_and_fee)
+    }
+
+    fn do_swaps(
+      mm: &SwapConfirmation,
+      trade: &Swap<T::AccountId, T::BlockNumber>,
+      trade_fee: Balance,
+      market_maker_trade: &Swap<T::AccountId, T::BlockNumber>,
+      market_maker_fee: Balance,
+    ) -> DispatchResult {
+      match Self::transfer_swap_funds_and_fees(
+        mm,
+        trade,
+        trade_fee,
+        market_maker_trade,
+        market_maker_fee,
+      ) {
+        Ok(_) => {
+          Swaps::<T>::try_mutate_exists(mm.request_id, |mm_trade_request| {
+            if let Some(market_maker_trade) = mm_trade_request {
+              market_maker_trade.amount_from_filled = market_maker_trade
+                .amount_from_filled
+                .checked_add(mm.amount_to_send)
+                .ok_or(Error::<T>::ArithmeticError)?;
+
+              market_maker_trade.amount_to_filled = market_maker_trade
+                .amount_to_filled
+                .checked_add(mm.amount_to_receive)
+                .ok_or(Error::<T>::ArithmeticError)?;
+
+              Self::update_swap_and_requestor_account(market_maker_trade, mm.request_id)
+                .map_err(|_| Error::<T>::UpdateMarketMakerSwapFailed)?;
+
+              // Emit market maker trade event on chain
+              Self::deposit_event(Event::<T>::SwapProcessed {
+                request_id: mm.request_id,
+                initial_extrinsic_hash: market_maker_trade.extrinsic_hash,
+                status: market_maker_trade.status.clone(),
+                account_id: market_maker_trade.account_id.clone(),
+                currency_from: market_maker_trade.token_from,
+                currency_amount_from: mm.amount_to_send,
+                currency_to: market_maker_trade.token_to,
+                currency_amount_to: mm.amount_to_receive,
+              });
+
+              // Delete swap if it is completed or its type is Market
+              if market_maker_trade.status == SwapStatus::Completed
+                || market_maker_trade.swap_type == SwapType::Market
+              {
+                *mm_trade_request = None;
+              }
+
+              Ok::<(), Error<T>>(())
+            } else {
+              Err(Error::<T>::InvalidRequestId.into())
+            }
+          })?;
+
+          Ok(())
+        }
+        Err(e) => Err(e.into()),
+      }
+    }
+
+    fn transfer_swap_funds_and_fees(
+      mm: &SwapConfirmation,
+      trade: &Swap<T::AccountId, T::BlockNumber>,
+      trade_fee: Balance,
+      market_maker_trade: &Swap<T::AccountId, T::BlockNumber>,
+      market_maker_fee: Balance,
+    ) -> Result<(), Error<T>> {
       // Transfer funds from the trader to market maker
       T::CurrencyTidefi::transfer_held(
         trade.token_from,
         &trade.account_id,
-        &market_maker_trade_intent.account_id,
+        &market_maker_trade.account_id,
         mm.amount_to_receive,
         false,
         false,
       )
-      .map_err(|_| Error::<T>::TransferFromTraderToMarketMakerFailed)?;
+      .map_err(|_| Error::<T>::TransferTraderSwapAssetsToMarketMakerFailed)?;
 
-      // Transfer trader fee to fees account
+      // Transfer trade fee to fees account
       T::CurrencyTidefi::transfer_held(
         trade.token_from,
         &trade.account_id,
         &T::Fees::account_id(),
-        trader_amount_and_fee.fee,
+        trade_fee,
         false,
         false,
       )
@@ -814,20 +814,20 @@ pub mod pallet {
       // Transfer funds from market maker to the trader
       T::CurrencyTidefi::transfer_held(
         trade.token_to,
-        &market_maker_trade_intent.account_id,
+        &market_maker_trade.account_id,
         &trade.account_id,
         mm.amount_to_send,
         false,
         false,
       )
-      .map_err(|_| Error::<T>::TransferFromMarketMakerToTraderFailed)?;
+      .map_err(|_| Error::<T>::TransferMarketMakerSwapAssetsToTraderFailed)?;
 
       // Transfer market maker fee to fees account
       T::CurrencyTidefi::transfer_held(
         trade.token_to,
-        &market_maker_trade_intent.account_id,
+        &market_maker_trade.account_id,
         &T::Fees::account_id(),
-        mm_amount_and_fee.fee,
+        market_maker_fee,
         false,
         false,
       )
@@ -835,21 +835,17 @@ pub mod pallet {
 
       // Register a new trading fees associated with the account.
       T::Fees::register_swap_fees(
-        market_maker_trade_intent.account_id.clone(),
+        market_maker_trade.account_id.clone(),
         trade.token_to,
         mm.amount_to_send,
-        market_maker_trade_intent.swap_type.clone(),
-        market_maker_trade_intent.is_market_maker,
+        market_maker_trade.swap_type.clone(),
+        market_maker_trade.is_market_maker,
       )
       .map_err(|_| Error::<T>::MarketMakerSwapFeeRegistrationFailed)?;
-
-      Self::update_swap_and_requestor_account(market_maker_trade_intent, mm.request_id)
-        .map_err(|_| Error::<T>::UpdateMarketMakerSwapFailed)?;
 
       Ok(())
     }
 
-    #[transactional]
     fn update_swap_and_requestor_account(
       swap: &mut Swap<T::AccountId, T::BlockNumber>,
       request_id: Hash,
@@ -860,12 +856,13 @@ pub mod pallet {
         swap.status = SwapStatus::PartiallyFilled;
       }
 
-      // Close the swap if it's complete or is a market order
       if swap.status == SwapStatus::Completed || swap.swap_type == SwapType::Market {
+        // Delete the swap from AccountSwaps, then release on hold funds
         Self::try_delete_account_swap(&swap.account_id, request_id)
           .map_err(|_| Error::<T>::DeleteSwapFailed)?;
         Self::swap_release_funds(swap).map_err(|_| Error::<T>::ReleaseUnswappedFundsFailed)?;
       } else {
+        // Update the swap status in AccountSwaps
         Self::try_update_account_swap_status(&swap.account_id, request_id, swap.status.clone())
           .map_err(|_| Error::<T>::UpdateAccountSwapRequestStatusFailed)?;
       }

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -203,7 +203,7 @@ pub mod pallet {
     InvalidRequestId,
     /// Invalid swap request status.
     InvalidRequestSwapStatus,
-    /// Request swap asset types must be different
+    /// Swap request assets must be different.
     SwapAssetTypesShouldBeDifferent,
     /// Invalid market maker request ID, includes an index in the SwapConfirmation list
     InvalidMarketMakerRequestId { index: u8 },

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -209,7 +209,7 @@ pub mod pallet {
     InvalidMarketMakerRequestId { index: u8 },
     /// Invalid market maker swap request status.
     InvalidMarketMakerSwapRequestStatus,
-    /// Market maker buy asset type does not match with sell asset type
+    /// Buyer and seller assets must match.
     TwoRequestsAssetTypesNotMatch,
     /// Unknown Asset.
     UnknownAsset,

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -225,7 +225,7 @@ pub mod pallet {
     OfferIsLessThanMarketMakerSwapLowerBound { index: u8 },
     /// Request contains offer that is greater than market maker swap upper bound
     OfferIsGreaterThanMarketMakerSwapUpperBound { index: u8 },
-    /// Market Maker swap do not have enough funds left to sell
+    /// Market Maker swap does not have enough funds left to sell
     MarketMakerSwapHasNotEnoughTokenLeftToSell,
     /// Trader swap do not have enough funds left to sell
     TraderSwapHasNotEnoughTokenLeftToSell,

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -38,7 +38,7 @@ pub mod pallet {
     inherent::Vec,
     pallet_prelude::*,
     traits::fungibles::{Inspect, InspectHold, Mutate, MutateHold, Transfer},
-    transactional, PalletId,
+    PalletId,
   };
   use frame_system::pallet_prelude::*;
   #[cfg(feature = "std")]
@@ -771,7 +771,6 @@ pub mod pallet {
 
   // helper functions (not dispatchable)
   impl<T: Config> Pallet<T> {
-    #[transactional]
     fn process_swap(
       trade: &Swap<T::AccountId, T::BlockNumber>,
       mm: &SwapConfirmation,
@@ -849,7 +848,6 @@ pub mod pallet {
       Ok(())
     }
 
-    #[transactional]
     fn update_swap_and_requestor_account(
       swap: &mut Swap<T::AccountId, T::BlockNumber>,
       request_id: Hash,

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -38,7 +38,7 @@ pub mod pallet {
     inherent::Vec,
     pallet_prelude::*,
     traits::fungibles::{Inspect, InspectHold, Mutate, MutateHold, Transfer},
-    PalletId,
+    transactional, PalletId,
   };
   use frame_system::pallet_prelude::*;
   #[cfg(feature = "std")]
@@ -771,6 +771,7 @@ pub mod pallet {
 
   // helper functions (not dispatchable)
   impl<T: Config> Pallet<T> {
+    #[transactional]
     fn process_swap(
       trade: &Swap<T::AccountId, T::BlockNumber>,
       mm: &SwapConfirmation,
@@ -848,6 +849,7 @@ pub mod pallet {
       Ok(())
     }
 
+    #[transactional]
     fn update_swap_and_requestor_account(
       swap: &mut Swap<T::AccountId, T::BlockNumber>,
       request_id: Hash,

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -2030,7 +2030,7 @@ mod confirm_swap {
                 amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS,
               },],
             ),
-            Error::<Test>::InvalidRequestSwapStatus
+            Error::<Test>::InvalidSwapStatus
           );
         }
       });
@@ -2076,7 +2076,7 @@ mod confirm_swap {
               amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS,
             },],
           ),
-          Error::<Test>::SwapAssetTypesShouldBeDifferent
+          Error::<Test>::SwapAssetsShouldBeDifferent
         );
       });
     }
@@ -2473,7 +2473,7 @@ mod confirm_swap {
               amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS,
             },],
           ),
-          Error::<Test>::TwoRequestsAssetTypesNotMatch
+          Error::<Test>::BuySellAssetMismatch
         );
       });
     }
@@ -2520,7 +2520,7 @@ mod confirm_swap {
               amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS,
             },],
           ),
-          Error::<Test>::TwoRequestsAssetTypesNotMatch
+          Error::<Test>::BuySellAssetMismatch
         );
       });
     }

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -1973,7 +1973,7 @@ mod confirm_swap {
               amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS,
             },],
           ),
-          Error::<Test>::MarketMakerHasNotEnoughTokenToSell
+          Error::<Test>::MarketMakerHasNotEnoughTokenToSellAndPaySwapFees
         );
       });
     }
@@ -2014,7 +2014,7 @@ mod confirm_swap {
               amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS.saturating_add(1),
             },],
           ),
-          Error::<Test>::MarketMakerHasNotEnoughTokenToSell
+          Error::<Test>::MarketMakerHasNotEnoughTokenToSellAndPaySwapFees
         );
       });
     }
@@ -2050,7 +2050,7 @@ mod confirm_swap {
               amount_to_send: CHARLIE_PARTIAL_FILLING_SELLS_100_TEMPS.saturating_mul(5),
             },],
           ),
-          Error::<Test>::TraderHasNotEnoughTokenToSell
+          Error::<Test>::TraderCannotOversell
         );
       });
     }


### PR DESCRIPTION
* Refactored Oracle pallet's `confirm_swap` extrinsic logic into multiple functions
* Throw an error immediately when any of the fund or fee transfer fails during the swap process
* Updated the tests for `confirm_swap` extrinsic