### PR TITLE
Issue356 - Updated oracle pallet swap validation and fund release logic based on market pair

### DIFF
--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -277,9 +277,7 @@ pub mod pallet {
     UpdateMarketMakerSwapFailed,
     /// Delete trader's swap request from Swaps failed
     DeleteSwapFailed,
-    /// Unable to release funds.
-    ReleaseFailed,
-    /// Release trader's unswapped funds failed
+    /// Release unswapped funds failed
     ReleaseUnswappedFundsFailed,
     /// Update trader's swap request status in AccountSwaps failed
     UpdateAccountSwapRequestStatusFailed,
@@ -1066,8 +1064,7 @@ pub mod pallet {
         )
         .ok_or(Error::<T>::ArithmeticError)?;
 
-      T::CurrencyTidefi::release(swap.token_from, &swap.account_id, amount_to_release, true)
-        .map_err(|_| Error::<T>::ReleaseFailed)?;
+      T::CurrencyTidefi::release(swap.token_from, &swap.account_id, amount_to_release, true)?;
 
       Ok(())
     }

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -374,7 +374,7 @@ pub mod pallet {
           trade.amount_from_filled += trade_sold_amount;
           trade.amount_to_filled += trade_bought_amount;
 
-          Self::update_swap_and_requestor_account(trade, request_id, false)
+          Self::update_swap_and_requestor_account(trade, request_id, trade.is_market_maker)
             .map_err(|_| Error::<T>::UpdateTraderSwapFailed)?;
 
           // Emit trade event on chain
@@ -754,7 +754,7 @@ pub mod pallet {
         mm.amount_to_receive,
         mm.amount_to_send,
         trade_latest_from_filled,
-        false,
+        trade.is_market_maker,
       )?;
 
       let market_maker_fee = Self::validate_fund_transfers(
@@ -958,7 +958,7 @@ pub mod pallet {
         trade.token_from,
         mm.amount_to_receive,
         trade.swap_type.clone(),
-        false,
+        trade.is_market_maker,
       )
       .map_err(|_| Error::<T>::TraderSwapFeeRegistrationFailed)?;
 

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -250,6 +250,28 @@ impl Context {
     )
   }
 
+  fn create_temp_to_tdfy_market_swap_request(
+    &self,
+    requester_account_id: AccountId,
+    temp_amount: Balance,
+    tdfy_amount: Balance,
+    extrinsic_hash: [u8; 32],
+    slippage: Permill,
+  ) -> Hash {
+    add_new_swap_and_assert_results(
+      requester_account_id,
+      TEMP_CURRENCY_ID,
+      temp_amount,
+      CurrencyId::Tdfy,
+      tdfy_amount,
+      CURRENT_BLOCK_NUMBER,
+      extrinsic_hash,
+      MarketMakers::<Test>::get(&requester_account_id).is_some(),
+      SwapType::Market,
+      slippage,
+    )
+  }
+
   fn create_zemp_to_temp_market_swap_request(
     &self,
     requester_account_id: AccountId,
@@ -1503,7 +1525,7 @@ mod confirm_swap {
         let tdfy_amount = 10 * ONE_TDFY;
         let temp_amount = 200 * ONE_TEMP;
 
-        let trade_request_id = context.create_temp_to_tdfy_limit_swap_request(
+        let trade_request_id = context.create_temp_to_tdfy_market_swap_request(
           CHARLIE_ACCOUNT_ID,
           temp_amount,
           tdfy_amount,
@@ -1611,7 +1633,129 @@ mod confirm_swap {
     }
 
     #[test]
-    fn limit_trade_created_by_market_maker() {}
+    fn limit_trade_created_by_market_maker() {
+      new_test_ext().execute_with(|| {
+        let context = Context::default()
+          .set_oracle_status(true)
+          .set_market_makers(vec![BOB_ACCOUNT_ID, CHARLIE_ACCOUNT_ID])
+          .mint_tdfy(ALICE_ACCOUNT_ID, ONE_TDFY)
+          .mint_tdfy(CHARLIE_ACCOUNT_ID, ONE_TDFY)
+          .mint_tdfy(BOB_ACCOUNT_ID, INITIAL_20_TDFYS)
+          .mint_temp(CHARLIE_ACCOUNT_ID, INITIAL_10000_TEMPS);
+
+        Fees::start_era();
+        assert!(Fees::current_era().is_some());
+        let current_era = Fees::current_era().unwrap().index;
+
+        let tdfy_amount = 10 * ONE_TDFY;
+        let temp_amount = 200 * ONE_TEMP;
+
+        let trade_request_id = context.create_temp_to_tdfy_limit_swap_request(
+          CHARLIE_ACCOUNT_ID,
+          temp_amount,
+          tdfy_amount,
+          EXTRINSIC_HASH_0,
+          SLIPPAGE_5_PERCENTS,
+        );
+
+        assert_eq!(
+          trade_request_id,
+          Hash::from_str("0x73e1c320c34f6de5adadaef0169fbfeaab43d277a95bf02593afc0cbeb496c61")
+            .unwrap_or_default()
+        );
+
+        let trade_request_mm_id = context.create_tdfy_to_temp_limit_swap_request(
+          BOB_ACCOUNT_ID,
+          tdfy_amount,
+          temp_amount,
+          EXTRINSIC_HASH_1,
+          SLIPPAGE_2_PERCENTS,
+        );
+
+        assert_eq!(
+          trade_request_mm_id,
+          Hash::from_str("0xe0424aac19ef997f1b76ac20d400aecc2ee0258d9eacb7013c3fcfa2e55bdc67")
+            .unwrap_or_default()
+        );
+
+        assert_ok!(Oracle::confirm_swap(
+          context.alice,
+          trade_request_id,
+          vec![SwapConfirmation {
+            request_id: trade_request_mm_id,
+            amount_to_receive: temp_amount,
+            amount_to_send: tdfy_amount,
+          },],
+        ));
+
+        // swap confirmation for charlie (mm user)
+        System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
+          request_id: trade_request_id,
+          status: SwapStatus::Completed,
+          account_id: CHARLIE_ACCOUNT_ID,
+          currency_from: TEMP_CURRENCY_ID,
+          currency_amount_from: temp_amount,
+          currency_to: CurrencyId::Tdfy,
+          currency_amount_to: tdfy_amount,
+          initial_extrinsic_hash: EXTRINSIC_HASH_0,
+        }));
+
+        // swap confirmation for bob (mm1)
+        System::assert_has_event(MockEvent::Oracle(Event::SwapProcessed {
+          request_id: trade_request_mm_id,
+          status: SwapStatus::Completed,
+          account_id: BOB_ACCOUNT_ID,
+          currency_from: CurrencyId::Tdfy,
+          currency_amount_from: tdfy_amount,
+          currency_to: TEMP_CURRENCY_ID,
+          currency_amount_to: temp_amount,
+          initial_extrinsic_hash: EXTRINSIC_HASH_1,
+        }));
+
+        // BOB and Charlie swaps are deleted
+        assert!(Oracle::swaps(trade_request_id).is_none());
+        assert!(Oracle::swaps(trade_request_mm_id).is_none());
+        account_swap_is_deleted(CHARLIE_ACCOUNT_ID, trade_request_id);
+        account_swap_is_deleted(BOB_ACCOUNT_ID, trade_request_mm_id);
+
+        // make sure all balances match
+        assert_eq!(
+          Adapter::balance(TEMP_CURRENCY_ID, &context.fees_account_id),
+          MARKET_MAKER_SWAP_FEE_RATE * temp_amount
+        );
+        assert_eq!(
+          Adapter::balance(CurrencyId::Tdfy, &context.fees_account_id),
+          // we burned 1 tdfy on start so it should contain 1.2 tdfy now
+          ONE_TDFY + MARKET_MAKER_SWAP_LIMIT_FEE_RATE * tdfy_amount
+        );
+
+        assert_eq!(
+          Adapter::balance(CurrencyId::Tdfy, &BOB_ACCOUNT_ID),
+          INITIAL_20_TDFYS
+            .saturating_sub(tdfy_amount)
+            .saturating_sub(MARKET_MAKER_SWAP_LIMIT_FEE_RATE * tdfy_amount)
+        );
+        assert_eq!(
+          Adapter::balance(TEMP_CURRENCY_ID, &BOB_ACCOUNT_ID),
+          BOB_BUYS_200_TEMPS
+        );
+
+        // make sure fees are registered on chain
+        let bob_fee = Fees::account_fees(current_era, BOB_ACCOUNT_ID);
+        assert_eq!(
+          bob_fee.first().unwrap().1.fee,
+          MARKET_MAKER_SWAP_LIMIT_FEE_RATE * tdfy_amount
+        );
+        assert_eq!(bob_fee.first().unwrap().1.amount, tdfy_amount);
+
+        let charlie_fee = Fees::account_fees(current_era, CHARLIE_ACCOUNT_ID);
+        assert_eq!(
+          charlie_fee.first().unwrap().1.fee,
+          MARKET_MAKER_SWAP_FEE_RATE * temp_amount
+        );
+        assert_eq!(charlie_fee.first().unwrap().1.amount, temp_amount);
+      });
+    }
 
     #[test]
     fn offer_partially_filled_with_price_equals_to_buying_price_upper_bound() {

--- a/frame/tidefi-stake/src/tests.rs
+++ b/frame/tidefi-stake/src/tests.rs
@@ -320,20 +320,15 @@ fn add_new_swap_and_assert_results(
   )
   .unwrap();
 
-  let swap_fee =
-    Fees::calculate_swap_fees(asset_id_from, amount_from, swap_type, is_market_maker).fee;
-
   assert_eq!(
     Adapter::balance_on_hold(asset_id_from, &account_id),
-    amount_from.saturating_add(swap_fee)
+    amount_from
   );
 
   if asset_id_from != CurrencyId::Tdfy {
     assert_eq!(
       Adapter::balance(asset_id_from, &account_id),
-      initial_from_token_balance
-        .saturating_sub(amount_from)
-        .saturating_sub(swap_fee)
+      initial_from_token_balance.saturating_sub(amount_from)
     );
   }
 
@@ -342,7 +337,6 @@ fn add_new_swap_and_assert_results(
     asset_id_from,
     initial_from_token_balance,
     amount_from,
-    swap_fee,
   );
 
   assert_eq!(trade_request.status, SwapStatus::Pending);
@@ -364,11 +358,8 @@ fn assert_spendable_balance_is_updated(
   currency_id: CurrencyId,
   initial_balance: Balance,
   sell_amount: Balance,
-  swap_fee: Balance,
 ) {
-  let expected_reducible_balance = initial_balance
-    .saturating_sub(sell_amount)
-    .saturating_sub(swap_fee);
+  let expected_reducible_balance = initial_balance.saturating_sub(sell_amount);
 
   match currency_id {
     CurrencyId::Tdfy => assert_eq!(
@@ -383,9 +374,7 @@ fn assert_spendable_balance_is_updated(
 
   assert_eq!(
     Adapter::reducible_balance(currency_id, &account_id, false),
-    initial_balance
-      .saturating_sub(sell_amount)
-      .saturating_sub(swap_fee)
+    initial_balance.saturating_sub(sell_amount)
   );
 }
 
@@ -714,13 +703,13 @@ mod unstake {
 
           // Calculate expected fees in both TDFYs and test tokens
           let total_fee_in_tdfy =
-            Fees::calculate_swap_fees(CurrencyId::Tdfy, SWAP_TDFY_AMOUNT, SwapType::Limit, false)
+            Fees::calculate_swap_fees(CurrencyId::Tdfy, SWAP_TDFY_AMOUNT, SwapType::Limit, true)
               .fee;
           let total_fee_in_test_token = Fees::calculate_swap_fees(
             TEST_TOKEN_CURRENCY_ID,
             SWAP_TEST_TOKEN_AMOUNT,
             SwapType::Limit,
-            true,
+            false,
           )
           .fee;
 
@@ -798,22 +787,20 @@ mod unstake {
 
           // Assert Bob TDFY and Test token balance
           assert_eq!(
-            BOB_INITIAL_ONE_THOUSAND_TDFYS - SWAP_TDFY_AMOUNT - total_fee_in_tdfy,
+            BOB_INITIAL_ONE_THOUSAND_TDFYS - SWAP_TDFY_AMOUNT,
             Adapter::balance(CurrencyId::Tdfy, &BOB_ACCOUNT_ID)
           );
           assert_eq!(
-            BOB_INITIAL_ONE_THOUSAND_TEST_TOKENS + SWAP_TEST_TOKEN_AMOUNT,
+            BOB_INITIAL_ONE_THOUSAND_TEST_TOKENS + SWAP_TEST_TOKEN_AMOUNT - total_fee_in_test_token,
             Adapter::balance(TEST_TOKEN_CURRENCY_ID, &BOB_ACCOUNT_ID)
           );
           // Assert Charlie TDFY and Test token balance
           assert_eq!(
-            CHARLIE_INITIAL_ONE_THOUSAND_TDFYS + SWAP_TDFY_AMOUNT,
+            CHARLIE_INITIAL_ONE_THOUSAND_TDFYS + SWAP_TDFY_AMOUNT - total_fee_in_tdfy,
             Adapter::balance(CurrencyId::Tdfy, &CHARLIE_ACCOUNT_ID)
           );
           assert_eq!(
-            CHARLIE_INITIAL_ONE_THOUSAND_TEST_TOKENS
-              - SWAP_TEST_TOKEN_AMOUNT
-              - total_fee_in_test_token,
+            CHARLIE_INITIAL_ONE_THOUSAND_TEST_TOKENS - SWAP_TEST_TOKEN_AMOUNT,
             Adapter::balance(TEST_TOKEN_CURRENCY_ID, &CHARLIE_ACCOUNT_ID)
           );
         });
@@ -906,13 +893,13 @@ mod unstake {
 
           // Calculate expected fees in both TDFYs and test tokens
           let total_fee_in_tdfy =
-            Fees::calculate_swap_fees(CurrencyId::Tdfy, SWAP_TDFY_AMOUNT, SwapType::Limit, false)
+            Fees::calculate_swap_fees(CurrencyId::Tdfy, SWAP_TDFY_AMOUNT, SwapType::Limit, true)
               .fee;
           let total_fee_in_test_token = Fees::calculate_swap_fees(
             TEST_TOKEN_CURRENCY_ID,
             SWAP_TEST_TOKEN_AMOUNT,
             SwapType::Limit,
-            true,
+            false,
           )
           .fee;
 
@@ -999,22 +986,20 @@ mod unstake {
 
           // Assert Bob TDFY and Test token balance
           assert_eq!(
-            BOB_INITIAL_ONE_THOUSAND_TDFYS - SWAP_TDFY_AMOUNT - total_fee_in_tdfy,
+            BOB_INITIAL_ONE_THOUSAND_TDFYS - SWAP_TDFY_AMOUNT,
             Adapter::balance(CurrencyId::Tdfy, &BOB_ACCOUNT_ID)
           );
           assert_eq!(
-            BOB_INITIAL_ONE_THOUSAND_TEST_TOKENS + SWAP_TEST_TOKEN_AMOUNT,
+            BOB_INITIAL_ONE_THOUSAND_TEST_TOKENS + SWAP_TEST_TOKEN_AMOUNT - total_fee_in_test_token,
             Adapter::balance(TEST_TOKEN_CURRENCY_ID, &BOB_ACCOUNT_ID)
           );
           // Assert Charlie TDFY and Test token balance
           assert_eq!(
-            CHARLIE_INITIAL_ONE_THOUSAND_TDFYS + SWAP_TDFY_AMOUNT,
+            CHARLIE_INITIAL_ONE_THOUSAND_TDFYS + SWAP_TDFY_AMOUNT - total_fee_in_tdfy,
             Adapter::balance(CurrencyId::Tdfy, &CHARLIE_ACCOUNT_ID)
           );
           assert_eq!(
-            CHARLIE_INITIAL_ONE_THOUSAND_TEST_TOKENS
-              - SWAP_TEST_TOKEN_AMOUNT
-              - total_fee_in_test_token,
+            CHARLIE_INITIAL_ONE_THOUSAND_TEST_TOKENS - SWAP_TEST_TOKEN_AMOUNT,
             Adapter::balance(TEST_TOKEN_CURRENCY_ID, &CHARLIE_ACCOUNT_ID)
           );
         });

--- a/frame/tidefi/src/mock.rs
+++ b/frame/tidefi/src/mock.rs
@@ -21,7 +21,7 @@ use frame_system as system;
 use frame_utils::construct_mock_runtime;
 use sp_runtime::traits::AccountIdConversion;
 use system::EnsureRoot;
-use tidefi_primitives::{BlockNumber, CurrencyId, SessionIndex};
+use tidefi_primitives::{assets, BlockNumber, CurrencyId, MarketPair, SessionIndex};
 
 use crate::pallet as pallet_tidefi;
 
@@ -276,7 +276,38 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     enabled: true,
     account: 1_u64.into(),
     market_makers: Vec::new(),
-    market_pairs: Vec::new(),
+    market_pairs: vec![
+      // ATH_USDC
+      MarketPair {
+        base_asset: assets::Asset::AllTimeHigh.currency_id(),
+        quote_asset: assets::Asset::USDCoin.currency_id(),
+      },
+      // BTC_USDC
+      MarketPair {
+        base_asset: assets::Asset::Bitcoin.currency_id(),
+        quote_asset: assets::Asset::USDCoin.currency_id(),
+      },
+      // ETH_USDC
+      MarketPair {
+        base_asset: assets::Asset::Ethereum.currency_id(),
+        quote_asset: assets::Asset::USDCoin.currency_id(),
+      },
+      // TDFY_BTC
+      MarketPair {
+        base_asset: assets::Asset::Tdfy.currency_id(),
+        quote_asset: assets::Asset::Bitcoin.currency_id(),
+      },
+      // TDFY_ETH
+      MarketPair {
+        base_asset: assets::Asset::Tdfy.currency_id(),
+        quote_asset: assets::Asset::Ethereum.currency_id(),
+      },
+      // TDFY_USDC
+      MarketPair {
+        base_asset: assets::Asset::Tdfy.currency_id(),
+        quote_asset: assets::Asset::USDCoin.currency_id(),
+      },
+    ],
   }
   .assimilate_storage(&mut storage)
   .unwrap();

--- a/frame/tidefi/src/tests.rs
+++ b/frame/tidefi/src/tests.rs
@@ -998,6 +998,35 @@ mod swap {
         );
       });
     }
+
+    #[test]
+    fn buy_and_sell_asset_types_are_different() {
+      new_test_ext().execute_with(|| {
+        let context = Context::default()
+          .mint_tdfy(ALICE_ACCOUNT_ID, 10 * ONE_TDFY)
+          .create_temp_asset_and_metadata()
+          .mint_temp(ALICE_ACCOUNT_ID, 10 * ONE_TEMP);
+
+        assert_ok!(Assets::freeze(
+          RuntimeOrigin::signed(context.sender),
+          TEMP_ASSET_ID,
+          ALICE_ACCOUNT_ID
+        ));
+
+        assert_noop!(
+          Tidefi::swap(
+            RuntimeOrigin::signed(context.sender),
+            CurrencyId::Tdfy,
+            10 * ONE_TEMP,
+            CurrencyId::Tdfy,
+            ONE_TDFY,
+            SwapType::Limit,
+            None
+          ),
+          OracleError::<Test>::MarketPairNotSupported
+        );
+      });
+    }
   }
 }
 

--- a/frame/tidefi/src/tests.rs
+++ b/frame/tidefi/src/tests.rs
@@ -46,11 +46,11 @@ const CHARLIE_ACCOUNT_ID: AccountId = AccountId(3);
 
 const ONE_TDFY: u128 = 1_000_000_000_000;
 
-const TEMP_ASSET_ID: u32 = 4;
+const TEMP_ASSET_ID: u32 = 5;
 const TEMP_CURRENCY_ID: CurrencyId = CurrencyId::Wrapped(TEMP_ASSET_ID);
 const TEMP_ASSET_IS_SUFFICIENT: bool = true;
 const TEMP_ASSET_MIN_BALANCE: u128 = 1;
-const ONE_TEMP: u128 = 100;
+const ONE_TEMP: u128 = 1_000_000;
 
 // TEMP Asset Metadata
 const TEMP_ASSET_NAME: &str = "TEMP";
@@ -1260,12 +1260,12 @@ mod cancel_swap {
 
           assert_noop!(
             Tidefi::cancel_swap(RuntimeOrigin::signed(BOB_ACCOUNT_ID), context.request_id),
-            OracleError::<Test>::ReleaseFailed
+            OracleError::<Test>::ReleaseUnswappedFundsFailed
           );
 
           assert_noop!(
             Tidefi::cancel_swap(RuntimeOrigin::signed(ALICE_ACCOUNT_ID), context.request_id),
-            OracleError::<Test>::ReleaseFailed
+            OracleError::<Test>::ReleaseUnswappedFundsFailed
           );
         });
       }
@@ -1290,12 +1290,12 @@ mod cancel_swap {
 
           assert_noop!(
             Tidefi::cancel_swap(RuntimeOrigin::signed(BOB_ACCOUNT_ID), context.request_id),
-            OracleError::<Test>::ReleaseFailed
+            OracleError::<Test>::ReleaseUnswappedFundsFailed
           );
 
           assert_noop!(
             Tidefi::cancel_swap(RuntimeOrigin::signed(ALICE_ACCOUNT_ID), context.request_id),
-            OracleError::<Test>::ReleaseFailed
+            OracleError::<Test>::ReleaseUnswappedFundsFailed
           );
         });
       }

--- a/frame/tidefi/src/tests.rs
+++ b/frame/tidefi/src/tests.rs
@@ -1023,7 +1023,7 @@ mod swap {
             SwapType::Limit,
             None
           ),
-          OracleError::<Test>::MarketPairNotSupported
+          Error::<Test>::SameCurrencyId
         );
       });
     }
@@ -1305,53 +1305,17 @@ mod cancel_swap {
   mod reported_tests {
     use super::*;
 
-    //  Test Case
-    // {
-    //     extrinsicHash: 0xaa2da68e072933bdb893c23221afb27fa54993666bdc17fbf58049bffac84790
-    //     accountId: fhEVp1YLd462wqi7ZZQ6kwsAJJoSiQTLryHr8haS47FVTJZiZ
-    //     isMarketMaker: true
-    //     tokenFrom: Tdfy
-    //     amountFrom: 358,691,894,374,000,000
-    //     amountFromFilled: 0
-    //     tokenTo: {
-    //       Wrapped: 3
-    //     }
-    //     amountTo: 27,601,341,270,000,000,000
-    //     amountToFilled: 0
-    //     status: Pending
-    //     swapType: Limit
-    //     blockNumber: 181,437
-    //     slippage: 0.00%
-    //   }
-
-    //   the user balance:
-    //   {
-    //     nonce: 7,723
-    //     consumers: 0
-    //     providers: 1
-    //     sufficients: 4
-    //     data: {
-    //       free: 2,510,661,247,398,669,860
-    //       reserved: 358,861,235,321,187,000
-    //       miscFrozen: 0
-    //       feeFrozen: 0
-    //     }
-    //   }
     #[test]
     fn from_tdfy_to_temp() {
-      let free_balance: u128 = 2_510_661_247_398_669_860;
       let from_amount: u128 = 358_691_894_374_000_000;
       let to_amount: u128 = 27_601_341_270_000_000_000;
-      let fee: u128 = 179_345_947_187_000; // MarketMakerLimitFeeAmount: 0.05% of from_amount
-      let reserved_balance: u128 = from_amount + fee;
-      let total: u128 = free_balance + reserved_balance;
 
       new_test_ext().execute_with(|| {
         let context = Context::default()
-          .mint_tdfy(ALICE_ACCOUNT_ID, 20 * ONE_TDFY)
-          .mint_tdfy(BOB_ACCOUNT_ID, total)
+          .mint_tdfy(ALICE_ACCOUNT_ID, ONE_TDFY)
+          .mint_tdfy(BOB_ACCOUNT_ID, 400_000 * ONE_TDFY)
           .create_temp_asset_and_metadata()
-          .mint_temp(ALICE_ACCOUNT_ID, to_amount);
+          .mint_temp(ALICE_ACCOUNT_ID, 30 * ONE_TEMP);
 
         Oracle::add_new_swap_in_queue(
           BOB_ACCOUNT_ID,
@@ -1380,8 +1344,11 @@ mod cancel_swap {
         let requester_balance_before = get_account_balance(BOB_ACCOUNT_ID, CurrencyId::Tdfy);
         let requester_reserved = get_account_reserved(BOB_ACCOUNT_ID, CurrencyId::Tdfy);
 
-        assert_eq!(requester_balance_before, free_balance);
-        assert_eq!(requester_reserved, reserved_balance);
+        assert_eq!(
+          requester_balance_before,
+          (400_000 * ONE_TDFY).saturating_sub(from_amount)
+        );
+        assert_eq!(requester_reserved, from_amount);
 
         assert_ok!(Tidefi::cancel_swap(
           RuntimeOrigin::signed(BOB_ACCOUNT_ID),


### PR DESCRIPTION
Changes include:
- Check swap asset type is either base asset or quote asset before passing asset amounts to the slippage validation call.
- Can oversell quote asset as we reserved with slippage amount when adding the swap, but not the for base asset.
- Update SwapStatus to Completed when either of the from or to asset is fully filled.
- Put the slippage into account when calculating the unused reserved fund when releasing
- Updated the tests