### PR TITLE
Added a migration for oracle pallet to remove the swaps without locking enough fund

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,9 +3975,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lru"
@@ -5027,6 +5027,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-utils",
+ "log",
  "pallet-asset-registry",
  "pallet-assets",
  "pallet-balances",
@@ -9899,7 +9900,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/frame/oracle/Cargo.toml
+++ b/frame/oracle/Cargo.toml
@@ -32,10 +32,11 @@ pallet-sunrise = { path = "../sunrise", default-features = false }
 pallet-asset-registry = { path = "../asset-registry", default-features = false }
 pallet-tidefi-stake = { path = "../tidefi-stake", default-features = false }
 frame-utils = { default-features = false, path = "../utils" }
+sp-core = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
+log = { version = "0.4.17", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.159" }
-sp-core = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 sp-io = { default-features = false, git = "https://github.com/tidelabs/substrate", branch = "tidechain" }
 
 [features]

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -25,11 +25,26 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
+pub mod migration;
+
 pub mod weights;
 pub use weights::*;
 
 // Re-export pallet items so that they can be accessed from the crate namespace.
 pub use pallet::*;
+
+pub(crate) const LOG_TARGET: &str = "tidefi::oracle";
+
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: $crate::LOG_TARGET,
+			concat!("[{:?}] 💸 ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -93,8 +108,12 @@ pub mod pallet {
       + MutateHold<Self::AccountId, AssetId = CurrencyId, Balance = Balance>;
   }
 
+  /// The current storage version.
+  const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
   #[pallet::pallet]
   #[pallet::generate_store(pub (super) trait Store)]
+  #[pallet::storage_version(STORAGE_VERSION)]
   pub struct Pallet<T>(_);
 
   /// Oracle is enabled

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
-pub mod migration;
+pub mod migrations;
 
 pub mod weights;
 pub use weights::*;

--- a/frame/oracle/src/migration.rs
+++ b/frame/oracle/src/migration.rs
@@ -1,0 +1,112 @@
+// Tidechain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tidechain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tidechain.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use frame_support::{
+  inherent::Vec,
+  traits::{fungibles::InspectHold, Get, OnRuntimeUpgrade, StorageVersion},
+  weights::Weight,
+  BoundedVec,
+};
+use sp_std::vec;
+use tidefi_primitives::{Hash, Swap, SwapStatus};
+
+pub mod v1 {
+  use sp_core::H256;
+
+  use super::*;
+
+  pub struct MigrationToV1<T>(sp_std::marker::PhantomData<T>);
+  impl<T: Config> OnRuntimeUpgrade for MigrationToV1<T> {
+    fn on_runtime_upgrade() -> Weight {
+      if StorageVersion::get::<Pallet<T>>() == 0 {
+        let mut reads = 1u64;
+        let mut writes = 0u64;
+        let mut invalid_swap_ids: Vec<H256> = vec![];
+
+        AccountSwaps::<T>::translate::<BoundedVec<(Hash, SwapStatus), T::SwapLimitByAccount>, _>(
+          |account_id, old_swaps_statuses| {
+            // Read AccountSwaps map
+            reads = reads.saturating_add(1);
+            // Write AccountSwaps map
+            writes = writes.saturating_add(1);
+
+            let mut new_swaps_statuses =
+              BoundedVec::<(Hash, SwapStatus), T::SwapLimitByAccount>::new();
+            for (swap_id, swap_status) in old_swaps_statuses.iter() {
+              // Read Swaps map
+              reads = reads.saturating_add(1);
+              match Swaps::<T>::get(swap_id) {
+                Some(swap) => {
+                  if *swap_status == SwapStatus::Pending {
+                    match swap.amount_from.checked_sub(swap.amount_from_filled) {
+                      Some(amount_from_left) => {
+                        let balance_on_hold =
+                          T::CurrencyTidefi::balance_on_hold(swap.token_from, &account_id);
+                        match balance_on_hold.checked_sub(amount_from_left) {
+                          // Keep swap in storage
+                          Some(_) => new_swaps_statuses
+                            .try_push((*swap_id, SwapStatus::Pending))
+                            .unwrap(),
+                          // Mark swap as invalid as not enough funds reserved
+                          None => invalid_swap_ids.push(*swap_id),
+                        }
+                      }
+                      None => invalid_swap_ids.push(*swap_id), // Mark swap as invalid as it is already fullfilled
+                    }
+                  } else {
+                    // Keep swap in storage if its status is not pending
+                    new_swaps_statuses
+                      .try_push((*swap_id, swap_status.clone()))
+                      .unwrap();
+                  }
+                }
+                None => {} // Remove swap from account swaps as its detail is not found in storage
+              }
+            }
+
+            if new_swaps_statuses.len() > 0 {
+              Some(new_swaps_statuses)
+            } else {
+              None
+            }
+          },
+        );
+
+        Swaps::<T>::translate::<Swap<T::AccountId, T::BlockNumber>, _>(|swap_id, old_swap| {
+          // Read Swaps map
+          reads = reads.saturating_add(1);
+          // Write Swaps map
+          writes = writes.saturating_add(1);
+
+          log!(info, "Invalid swap {:?} is deleted successfully", swap_id);
+
+          if invalid_swap_ids.contains(&swap_id) {
+            None
+          } else {
+            Some(old_swap)
+          }
+        });
+
+        log!(info, "Oracle migration v1 applied successfully");
+
+        StorageVersion::new(1).put::<Pallet<T>>();
+
+        T::DbWeight::get().reads_writes(reads, writes)
+      } else {
+        log!(warn, "Oracle migration skipping v1, should be removed");
+        T::DbWeight::get().reads(1)
+      }
+    }
+  }
+}

--- a/runtime/lagoon/src/lib.rs
+++ b/runtime/lagoon/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
   // 1.10-1 -> 1101
   // 2.4 -> 2040
   // 2.14 -> 2140
-  spec_version: 7010,
+  spec_version: 7020,
   impl_version: 0,
   apis: crate::api::PRUNTIME_API_VERSIONS,
   transaction_version: 1,
@@ -275,6 +275,8 @@ pub type Executive = frame_executive::Executive<
     MigrateBountyToV4<Runtime>,
     // Migration for moving preimage from V0 to V1 storage.
     pallet_preimage::migration::v1::Migration<Runtime>,
+    // Migration to delete swaps without locking enough fund
+    pallet_oracle::migration::v1::MigrationToV1<Runtime>,
   ),
 >;
 

--- a/runtime/lagoon/src/lib.rs
+++ b/runtime/lagoon/src/lib.rs
@@ -276,7 +276,7 @@ pub type Executive = frame_executive::Executive<
     // Migration for moving preimage from V0 to V1 storage.
     pallet_preimage::migration::v1::Migration<Runtime>,
     // Migration to delete swaps without locking enough fund
-    pallet_oracle::migration::v1::MigrationToV1<Runtime>,
+    pallet_oracle::migrations::v1::Migration<Runtime>,
   ),
 >;
 

--- a/runtime/tidechain/src/lib.rs
+++ b/runtime/tidechain/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
   // 1.10-1 -> 1101
   // 2.4 -> 2040
   // 2.14 -> 2140
-  spec_version: 7010,
+  spec_version: 7020,
   impl_version: 0,
   apis: crate::api::PRUNTIME_API_VERSIONS,
   transaction_version: 1,
@@ -276,6 +276,8 @@ pub type Executive = frame_executive::Executive<
     MigrateBountyToV4<Runtime>,
     // Migration for moving preimage from V0 to V1 storage.
     pallet_preimage::migration::v1::Migration<Runtime>,
+    // Migration to delete swaps without locking enough fund
+    pallet_oracle::migration::v1::MigrationToV1<Runtime>,
   ),
 >;
 

--- a/runtime/tidechain/src/lib.rs
+++ b/runtime/tidechain/src/lib.rs
@@ -277,7 +277,7 @@ pub type Executive = frame_executive::Executive<
     // Migration for moving preimage from V0 to V1 storage.
     pallet_preimage::migration::v1::Migration<Runtime>,
     // Migration to delete swaps without locking enough fund
-    pallet_oracle::migration::v1::MigrationToV1<Runtime>,
+    pallet_oracle::migrations::v1::Migration<Runtime>,
   ),
 >;
 


### PR DESCRIPTION
This PR is used to remove all swaps without locking enough funds:
* It adds a migration.rs file to the runtime upgrade to scan all items in AccountSwaps map
* Check each pending swap requester's reserved balance, if the locked amount is less than the swap amount, it will be deleted from both AccountSwaps map and Swaps map.
* Storage version of the oracle pallet will be increased from 0 to 1 to make sure this migration only be applied once.
* Spec version will be updated from 7010 to 7020.